### PR TITLE
wyBin score update

### DIFF
--- a/src/app/components/dialogs/send-final-result/send-final-result.component.html
+++ b/src/app/components/dialogs/send-final-result/send-final-result.component.html
@@ -75,8 +75,12 @@
 
 			<hr />
 
+			<div class="loading" *ngIf="loading == true">
+				<mat-spinner [diameter]="35" class="spinner"></mat-spinner> updating the score on the wyBin tournament...
+			</div>
+
 			<mat-dialog-actions align="end">
-				<button mat-raised-button [mat-dialog-close]="returnData()" color="primary">Send final result</button>
+				<button mat-raised-button (click)="returnData()" color="primary">Send final result</button>
 			</mat-dialog-actions>
 		</mat-step>
 	</mat-horizontal-stepper>

--- a/src/app/components/dialogs/send-final-result/send-final-result.component.scss
+++ b/src/app/components/dialogs/send-final-result/send-final-result.component.scss
@@ -1,0 +1,8 @@
+.loading {
+	display: flex;
+	align-items: center;
+
+	.spinner {
+		margin-right: 8px;
+	}
+}

--- a/src/app/components/dialogs/send-final-result/send-final-result.component.ts
+++ b/src/app/components/dialogs/send-final-result/send-final-result.component.ts
@@ -1,8 +1,12 @@
 import { Component, OnInit, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { MatButtonToggleChange } from '@angular/material/button-toggle';
 import { IMultiplayerLobbySendFinalMessageDialogData } from 'app/interfaces/i-multiplayer-lobby-send-final-message-dialog-data';
+import { LobbyViewComponent } from 'app/modules/lobby/components/lobby-view/lobby-view.component';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { AppConfig } from 'environments/environment';
+import { ToastService } from 'app/services/toast.service';
 
 @Component({
 	selector: 'app-send-final-result',
@@ -10,6 +14,8 @@ import { IMultiplayerLobbySendFinalMessageDialogData } from 'app/interfaces/i-mu
 	styleUrls: ['./send-final-result.component.scss']
 })
 export class SendFinalResultComponent implements OnInit {
+	private readonly apiUrl = AppConfig.apiUrl;
+
 	firstStepFormGroup: FormGroup;
 	secondStepFormGroup: FormGroup;
 
@@ -17,7 +23,9 @@ export class SendFinalResultComponent implements OnInit {
 
 	canSend = false;
 
-	constructor(@Inject(MAT_DIALOG_DATA) public data: IMultiplayerLobbySendFinalMessageDialogData) {
+	loading = false;
+
+	constructor(@Inject(MAT_DIALOG_DATA) public data: IMultiplayerLobbySendFinalMessageDialogData, private dialogRef: MatDialogRef<LobbyViewComponent>, private http: HttpClient, private toastService: ToastService) {
 		this.firstStepFormGroup = new FormGroup({
 			'match-outcome': new FormControl('', Validators.required),
 			'extra-message': new FormControl()
@@ -43,7 +51,7 @@ export class SendFinalResultComponent implements OnInit {
 		this.secondStepFormGroup.markAllAsTouched();
 	}
 
-	returnData(): IMultiplayerLobbySendFinalMessageDialogData {
+	returnData() {
 		let winningTeam = null;
 		let losingTeam = null;
 
@@ -56,13 +64,40 @@ export class SendFinalResultComponent implements OnInit {
 			losingTeam = this.data.multiplayerLobby.getTeamOneScore() > this.data.multiplayerLobby.getTeamTwoScore() ? this.data.multiplayerLobby.teamTwoName : this.data.multiplayerLobby.teamOneName;
 		}
 
-		return {
+		const wyBinTournamentId = this.data.multiplayerLobby.tournament.wyBinTournamentId;
+
+		if (wyBinTournamentId != null && wyBinTournamentId != undefined) {
+			this.loading = true;
+
+			this.http.post<any>(`${this.apiUrl}tournament-wyreferee-score-update`, {
+				tournamentId: wyBinTournamentId,
+				stageName: this.data.multiplayerLobby.selectedStage.name,
+				multiplayerLink: this.data.multiplayerLobby.multiplayerLink,
+				opponentOne: this.data.multiplayerLobby.teamOneName,
+				opponentTwo: this.data.multiplayerLobby.teamTwoName,
+				opponentOneScore: this.data.multiplayerLobby.getTeamOneScore(),
+				opponentTwoScore: this.data.multiplayerLobby.getTeamTwoScore(),
+				winByDefaultWinner: this.secondStepFormGroup.get('winning-team').value
+			}).subscribe(() => {
+				this.closeDialog(winningTeam, losingTeam);
+			}, (err: HttpErrorResponse) => {
+				this.toastService.addToast(err.error.message);
+				this.closeDialog(winningTeam, losingTeam);
+			});
+		}
+		else {
+			this.closeDialog(winningTeam, losingTeam);
+		}
+	}
+
+	closeDialog(winningTeam: string, losingTeam: string): void {
+		this.dialogRef.close({
 			winningTeam: winningTeam,
 			losingTeam: losingTeam,
 			winByDefault: this.isWinByDefault,
 			multiplayerLobby: this.data.multiplayerLobby,
 			extraMessage: this.firstStepFormGroup.get('extra-message').value,
 			qualifierLobby: this.firstStepFormGroup.get('match-outcome').value == 'qualifier-result' ? true : false
-		};
+		});
 	}
 }

--- a/src/app/components/dialogs/send-final-result/send-final-result.component.ts
+++ b/src/app/components/dialogs/send-final-result/send-final-result.component.ts
@@ -77,7 +77,9 @@ export class SendFinalResultComponent implements OnInit {
 				opponentTwo: this.data.multiplayerLobby.teamTwoName,
 				opponentOneScore: this.data.multiplayerLobby.getTeamOneScore(),
 				opponentTwoScore: this.data.multiplayerLobby.getTeamTwoScore(),
-				winByDefaultWinner: this.secondStepFormGroup.get('winning-team').value
+				winByDefaultWinner: this.secondStepFormGroup.get('winning-team').value,
+				opponentOneBans: this.data.multiplayerLobby.teamOneBans,
+				opponentTwoBans: this.data.multiplayerLobby.teamTwoBans
 			}).subscribe(() => {
 				this.closeDialog(winningTeam, losingTeam);
 			}, (err: HttpErrorResponse) => {

--- a/src/app/components/dialogs/send-final-result/send-final-result.component.ts
+++ b/src/app/components/dialogs/send-final-result/send-final-result.component.ts
@@ -14,16 +14,14 @@ import { ToastService } from 'app/services/toast.service';
 	styleUrls: ['./send-final-result.component.scss']
 })
 export class SendFinalResultComponent implements OnInit {
-	private readonly apiUrl = AppConfig.apiUrl;
-
 	firstStepFormGroup: FormGroup;
 	secondStepFormGroup: FormGroup;
 
 	isWinByDefault = false;
-
 	canSend = false;
-
 	loading = false;
+
+	private readonly apiUrl = AppConfig.apiUrl;
 
 	constructor(@Inject(MAT_DIALOG_DATA) public data: IMultiplayerLobbySendFinalMessageDialogData, private dialogRef: MatDialogRef<LobbyViewComponent>, private http: HttpClient, private toastService: ToastService) {
 		this.firstStepFormGroup = new FormGroup({

--- a/src/app/models/lobby.ts
+++ b/src/app/models/lobby.ts
@@ -114,7 +114,7 @@ export class Lobby {
 			teamSize: lobby.teamSize,
 			mappoolId: lobby.mappoolId,
 			mappool: lobby.mappool != null ? WyMappool.makeTrueCopy(lobby.mappool) : null,
-			ircChannel: IrcChannel.makeTrueCopy(lobby.ircChannel),
+			ircChannel: lobby.ircChannel,
 			firstPick: lobby.firstPick,
 			selectedStage: lobby.selectedStage != null ? WyStage.makeTrueCopy(lobby.selectedStage) : null,
 			bestOf: lobby.bestOf,
@@ -573,8 +573,6 @@ export class Lobby {
 							for (let i = 0; i < this.teamOneSlotArray.length; i++) {
 								teamSlotString += (this.teamOneSlotArray[i] + 1);
 
-								console.log(i, this.teamOneSlotArray.length);
-
 								if (i != (this.teamOneSlotArray.length - 2)) {
 									teamSlotString += ', ';
 								}
@@ -592,8 +590,6 @@ export class Lobby {
 
 							for (let i = 0; i < this.teamTwoSlotArray.length; i++) {
 								teamSlotString += (this.teamTwoSlotArray[i] + 1);
-
-								console.log(i, this.teamTwoSlotArray.length);
 
 								if (i != (this.teamTwoSlotArray.length - 2)) {
 									teamSlotString += ', ';

--- a/src/app/models/wytournament/wy-tournament.ts
+++ b/src/app/models/wytournament/wy-tournament.ts
@@ -42,6 +42,8 @@ export class WyTournament {
 	allowDoublePick: boolean;
 	lobbyTeamNameWithBrackets: boolean;
 
+	wyBinTournamentId: number;
+
 	availableTo: User[];
 
 	administrators: User[];
@@ -95,7 +97,8 @@ export class WyTournament {
 			creationDate: new Date(tournament.creationDate),
 			allowDoublePick: tournament.allowDoublePick,
 			invalidateBeatmaps: tournament.invalidateBeatmaps,
-			lobbyTeamNameWithBrackets: tournament.lobbyTeamNameWithBrackets
+			lobbyTeamNameWithBrackets: tournament.lobbyTeamNameWithBrackets,
+			wyBinTournamentId: tournament.wyBinTournamentId
 		});
 
 		for (const team in tournament.teams) {

--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -220,11 +220,19 @@
 					<mat-icon>settings</mat-icon>
 				</div>
 
+				<div class="header-button" matTooltip="Synchronize the scores of this multiplayer lobby" (click)="synchronizeMp()">
+					<mat-icon>sync</mat-icon>
+				</div>
+
 				<div class="header-button" matTooltip="Go to multiplayer lobby match overview" (click)="navigateLobbyOverview()" *ngIf="selectedLobby && (selectedLobby.tournament != null || selectedLobby.tournament != undefined)">
 					<mat-icon>list</mat-icon>
 				</div>
 
 				<div class="header-button" matTooltip="Send beatmap result to irc" (click)="sendMatchResult()" *ngIf="selectedLobby && (selectedLobby.tournament != null || selectedLobby.tournament != undefined)">
+					<mat-icon>chat</mat-icon>
+				</div>
+
+				<div class="header-button" matTooltip="Send final result to Discord webhook" (click)="sendFinalResult()" *ngIf="selectedLobby && (selectedLobby.tournament != null || selectedLobby.tournament != undefined)">
 					<mat-icon>send</mat-icon>
 				</div>
 			</div>

--- a/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
+++ b/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
@@ -103,24 +103,6 @@ export class CreateLobbyComponent implements OnInit {
 
 	ngOnInit() { }
 
-	private initializeFilters() {
-		this.teamOneFilter = this.validationForm.get('team-one-name').valueChanges.pipe(
-			startWith(''),
-			map((value: string) => {
-				const filterValue = value.toLowerCase();
-				return this.selectedTournament.teams.filter(option => option.name.toLowerCase().includes(filterValue));
-			})
-		);
-
-		this.teamTwoFilter = this.validationForm.get('team-two-name').valueChanges.pipe(
-			startWith(''),
-			map((value: string) => {
-				const filterValue = value.toLowerCase();
-				return this.selectedTournament.teams.filter(option => option.name.toLowerCase().includes(filterValue));
-			})
-		);
-	}
-
 	changeTournament() {
 		this.selectedTournament = this.tournamentService.getTournamentById(this.validationForm.get('selected-tournament').value);
 		this.changeTeamSize(this.selectedTournament != null ? this.selectedTournament.teamSize : null);
@@ -365,5 +347,23 @@ export class CreateLobbyComponent implements OnInit {
 			this.validationForm.addControl('team-one-name', new FormControl('', Validators.required));
 			this.validationForm.addControl('team-two-name', new FormControl('', Validators.required));
 		}
+	}
+
+	private initializeFilters() {
+		this.teamOneFilter = this.validationForm.get('team-one-name').valueChanges.pipe(
+			startWith(''),
+			map((value: string) => {
+				const filterValue = value.toLowerCase();
+				return this.selectedTournament.teams.filter(option => option.name.toLowerCase().includes(filterValue));
+			})
+		);
+
+		this.teamTwoFilter = this.validationForm.get('team-two-name').valueChanges.pipe(
+			startWith(''),
+			map((value: string) => {
+				const filterValue = value.toLowerCase();
+				return this.selectedTournament.teams.filter(option => option.name.toLowerCase().includes(filterValue));
+			})
+		);
 	}
 }

--- a/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
+++ b/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
@@ -98,6 +98,12 @@ export class CreateLobbyComponent implements OnInit {
 			'selected-tournament': new FormControl('')
 		});
 
+		this.initializeFilters();
+	}
+
+	ngOnInit() { }
+
+	private initializeFilters() {
 		this.teamOneFilter = this.validationForm.get('team-one-name').valueChanges.pipe(
 			startWith(''),
 			map((value: string) => {
@@ -114,8 +120,6 @@ export class CreateLobbyComponent implements OnInit {
 			})
 		);
 	}
-
-	ngOnInit() { }
 
 	changeTournament() {
 		this.selectedTournament = this.tournamentService.getTournamentById(this.validationForm.get('selected-tournament').value);
@@ -139,6 +143,8 @@ export class CreateLobbyComponent implements OnInit {
 		this.validationForm.removeControl('challonge-tournament');
 
 		this.lobbyWithBrackets = this.selectedTournament.lobbyTeamNameWithBrackets;
+
+		this.initializeFilters();
 
 		// TODO: re-implement challonge integration
 		// this.checkingChallongeIntegration = true;

--- a/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.html
+++ b/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.html
@@ -1,6 +1,7 @@
 <app-alert alertType="info">If you do not have a tournament hosted on wyBin, you can skip this step.</app-alert>
 
 <p>Here you can link a wyBin tournament to your wyReferee tournament. When a referee sends the final result of the match, it will update the score on the wyBin tournament as well as update the stats for that given match. </p>
+<p>Make sure the stages you create on wyReferee match the ones you create on your wyBin tournament. If they do not match, it will not automatically update the scores.</p>
 
 <h3>wyBin Tournament</h3>
 

--- a/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.html
+++ b/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.html
@@ -1,0 +1,16 @@
+<app-alert alertType="info">If you do not have a tournament hosted on wyBin, you can skip this step.</app-alert>
+
+<p>Here you can link a wyBin tournament to your wyReferee tournament. When a referee sends the final result of the match, it will update the score on the wyBin tournament as well as update the stats for that given match. </p>
+
+<h3>wyBin Tournament</h3>
+
+<mat-form-field class="full-width" *ngIf="tournaments.length > 0">
+	<mat-label>wyBin tournaments</mat-label>
+	<mat-select (selectionChange)="onWyBinTournamentChange($event)" [value]="tournament.wyBinTournamentId">
+		<mat-option [value]="tournament.id" *ngFor="let tournament of tournaments">{{ tournament.name }}</mat-option>
+	</mat-select>
+</mat-form-field>
+
+<app-alert alertType="info" *ngIf="tournaments.length <= 0">No tournaments have been found. </app-alert>
+
+<p>Select the tournament from the dropdown list to which this tournament belongs to.</p>

--- a/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.spec.ts
+++ b/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TournamentWybinComponent } from './tournament-wybin.component';
+
+describe('TournamentWybinComponent', () => {
+	let component: TournamentWybinComponent;
+	let fixture: ComponentFixture<TournamentWybinComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [TournamentWybinComponent]
+		})
+			.compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(TournamentWybinComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.ts
+++ b/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.ts
@@ -10,11 +10,10 @@ import { AppConfig } from 'environments/environment';
 	styleUrls: ['./tournament-wybin.component.scss']
 })
 export class TournamentWybinComponent implements OnInit {
-	private readonly apiUrl = AppConfig.apiUrl;
-
 	@Input() tournament: WyTournament;
+	tournaments: { id: number; name: string }[];
 
-	tournaments: { id: number, name: string }[];
+	private readonly apiUrl = AppConfig.apiUrl;
 
 	constructor(private http: HttpClient) {
 		this.tournaments = [];
@@ -25,7 +24,7 @@ export class TournamentWybinComponent implements OnInit {
 			for (const tournament of tournaments) {
 				this.tournaments.push({ id: tournament.id, name: tournament.name });
 			}
-		})
+		});
 	}
 
 	onWyBinTournamentChange(wyBinTournament: MatSelectChange) {

--- a/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.ts
+++ b/src/app/modules/tournament-management/components/tournament/tournament-wybin/tournament-wybin.component.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, Input, OnInit } from '@angular/core';
+import { MatSelectChange } from '@angular/material/select';
+import { WyTournament } from 'app/models/wytournament/wy-tournament';
+import { AppConfig } from 'environments/environment';
+
+@Component({
+	selector: 'app-tournament-wybin',
+	templateUrl: './tournament-wybin.component.html',
+	styleUrls: ['./tournament-wybin.component.scss']
+})
+export class TournamentWybinComponent implements OnInit {
+	private readonly apiUrl = AppConfig.apiUrl;
+
+	@Input() tournament: WyTournament;
+
+	tournaments: { id: number, name: string }[];
+
+	constructor(private http: HttpClient) {
+		this.tournaments = [];
+	}
+
+	ngOnInit(): void {
+		this.http.get<any[]>(`${this.apiUrl}tournament`).subscribe(tournaments => {
+			for (const tournament of tournaments) {
+				this.tournaments.push({ id: tournament.id, name: tournament.name });
+			}
+		})
+	}
+
+	onWyBinTournamentChange(wyBinTournament: MatSelectChange) {
+		this.tournament.wyBinTournamentId = wyBinTournament.value;
+	}
+}

--- a/src/app/modules/tournament-management/components/tournament/tournament/tournament.component.html
+++ b/src/app/modules/tournament-management/components/tournament/tournament/tournament.component.html
@@ -4,6 +4,10 @@
 			<app-tournament-general [tournament]="tournament" [validationForm]="validationForm"></app-tournament-general>
 		</mat-tab>
 
+		<mat-tab label="wyBin">
+			<app-tournament-wybin [tournament]="tournament"></app-tournament-wybin>
+		</mat-tab>
+
 		<mat-tab label="Participants">
 			<app-tournament-participants [tournament]="tournament" [validationForm]="validationForm"></app-tournament-participants>
 		</mat-tab>

--- a/src/app/modules/tournament-management/tournament-management.module.ts
+++ b/src/app/modules/tournament-management/tournament-management.module.ts
@@ -21,6 +21,7 @@ import { TournamentEditComponent } from './components/tournament-edit/tournament
 import { TournamentMyPublishedComponent } from './components/tournament-my-published/tournament-my-published.component';
 import { TournamentOverviewComponent } from './components/tournament-overview/tournament-overview.component';
 import { TournamentPublishedEditComponent } from './components/tournament-published-edit/tournament-published-edit.component';
+import { TournamentWybinComponent } from './components/tournament/tournament-wybin/tournament-wybin.component';
 
 @NgModule({
 	declarations: [
@@ -41,7 +42,8 @@ import { TournamentPublishedEditComponent } from './components/tournament-publis
 		TournamentEditComponent,
 		TournamentMyPublishedComponent,
 		TournamentOverviewComponent,
-		TournamentPublishedEditComponent
+		TournamentPublishedEditComponent,
+		TournamentWybinComponent
 	],
 	imports: [
 		CommonModule,


### PR DESCRIPTION
Implement a way to connect a wyBin tournament to a wyReferee tournament
When a tournament is linked, it'll update the match score and bans when the final webhook gets sent, as well as update the stats for that match
