### PR TITLE
Score interface refactor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,7 +55,8 @@
 				"object-shorthand": 0,
 				"guard-for-in": 0,
 				"no-bitwise": 0,
-				"radix": 0
+				"radix": 0,
+				"jsdoc/newline-after-description": 0
 			}
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"electron-reload": "1.5.0",
 		"eslint": "^7.8.1",
 		"eslint-plugin-import": "^2.22.0",
-		"eslint-plugin-jsdoc": "38.1.6",
+		"eslint-plugin-jsdoc": "^43.1.1",
 		"eslint-plugin-prefer-arrow": "1.2.3",
 		"howler": "^2.1.3",
 		"jasmine-core": "^4.0.1",

--- a/src/app/models/score-calculation/calculation-types/axs-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/axs-calculation.ts
@@ -10,6 +10,7 @@ export class AxSCalculation extends ScoreInterface {
 		this.setTeamSize(teamSize);
 		this.setDescription(`The score calculation that is used for a tournament called AxS. The team size is set to ${teamSize}, where the first player in the multiplayerlobby is the accuracy player and the second and third are score players.`);
 		this.setSoloTournament(false);
+		this.setUseStaticSlots(true);
 	}
 
 	/**

--- a/src/app/models/score-calculation/calculation-types/oml-score-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/oml-score-calculation.ts
@@ -34,8 +34,8 @@ export class OMLScoreCalculation extends ScoreInterface {
 	calculateTeamOneScore() {
 		let teamScore = 0;
 
-		for (let i = 0; i < this.getTeamSize(); i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamRedUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;
@@ -44,8 +44,8 @@ export class OMLScoreCalculation extends ScoreInterface {
 	calculateTeamTwoScore() {
 		let teamScore = 0;
 
-		for (let i = this.getTeamSize(); i < this.getTeamSize() * 2; i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamBlueUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;

--- a/src/app/models/score-calculation/calculation-types/score-interface.ts
+++ b/src/app/models/score-calculation/calculation-types/score-interface.ts
@@ -1,4 +1,4 @@
-import { MultiplayerDataUser } from '../../store-multiplayer/multiplayer-data-user';
+import { MultiplayerDataUser, Team } from '../../store-multiplayer/multiplayer-data-user';
 
 /**
  * An interface with some methods that help you implement different score calculations
@@ -9,6 +9,9 @@ export abstract class ScoreInterface {
 	private teamSize: number;
 	private soloTournament: boolean;
 	private allUsers: MultiplayerDataUser[];
+	private teamRedUsers: MultiplayerDataUser[];
+	private teamBlueUsers: MultiplayerDataUser[];
+	private useStaticSlots: boolean;
 
 	/**
 	 * Initialize the score interface with the given identifier
@@ -18,7 +21,10 @@ export abstract class ScoreInterface {
 	constructor(identifier: string) {
 		this.identifier = identifier;
 		this.allUsers = [];
+		this.teamRedUsers = [];
+		this.teamBlueUsers = [];
 		this.soloTournament = null;
+		this.useStaticSlots = false;
 	}
 
 	/**
@@ -31,7 +37,7 @@ export abstract class ScoreInterface {
 			return;
 		}
 
-		this.allUsers[user.slot] = user;
+		this.allUsers.push(user);
 	}
 
 	/**
@@ -43,6 +49,8 @@ export abstract class ScoreInterface {
 		for (const user of users) {
 			this.addUserScore(user);
 		}
+
+		this.populateTeamArrays();
 	}
 
 	/**
@@ -72,6 +80,20 @@ export abstract class ScoreInterface {
 		newUser.mods = null;
 
 		return newUser;
+	}
+
+	/**
+	 * Gets all the users that are part of team red
+	 */
+	public getTeamRedUsers(): MultiplayerDataUser[] {
+		return this.teamRedUsers;
+	}
+
+	/**
+	 * Get all the users that are part of team blue
+	 */
+	public getTeamBlueUsers(): MultiplayerDataUser[] {
+		return this.teamBlueUsers;
 	}
 
 	/**
@@ -132,6 +154,30 @@ export abstract class ScoreInterface {
 	 */
 	public setSoloTournament(solo: boolean): void {
 		this.soloTournament = solo;
+	}
+
+	/**
+	 * Set whether to use static slots or not. This is only to properly visualize the lobby screen.
+	 * The actual score calculations should be done in the appropriate score interface
+	 *
+	 * @param useStaticSlots whether to use static slots or not
+	 */
+	public setUseStaticSlots(useStaticSlots: boolean): void {
+		this.useStaticSlots = useStaticSlots;
+	}
+
+	/**
+	 * Populates the team arrays with the appropriate players
+	 */
+	private populateTeamArrays(): void {
+		for (const player of this.allUsers) {
+			if (player.team == Team.Red) {
+				this.teamRedUsers.push(player);
+			}
+			else if (player.team == Team.Blue) {
+				this.teamBlueUsers.push(player);
+			}
+		}
 	}
 
 	/**

--- a/src/app/models/score-calculation/calculation-types/score-interface.ts
+++ b/src/app/models/score-calculation/calculation-types/score-interface.ts
@@ -167,6 +167,13 @@ export abstract class ScoreInterface {
 	}
 
 	/**
+	 * Check whether the score interface uses static slots
+	 */
+	public usesStaticSlots(): boolean {
+		return this.useStaticSlots;
+	}
+
+	/**
 	 * Populates the team arrays with the appropriate players
 	 */
 	private populateTeamArrays(): void {

--- a/src/app/models/score-calculation/calculation-types/team-vs-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/team-vs-calculation.ts
@@ -15,8 +15,8 @@ export class TeamVsCalculation extends ScoreInterface {
 	calculateTeamOneScore() {
 		let teamScore = 0;
 
-		for (let i = 0; i < this.getTeamSize(); i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamRedUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;
@@ -25,8 +25,8 @@ export class TeamVsCalculation extends ScoreInterface {
 	calculateTeamTwoScore() {
 		let teamScore = 0;
 
-		for (let i = this.getTeamSize(); i < this.getTeamSize() * 2; i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamBlueUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;

--- a/src/app/models/score-calculation/calculation-types/team-vs-hidden-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/team-vs-hidden-calculation.ts
@@ -14,11 +14,11 @@ export class TeamVsHiddenCalculation extends ScoreInterface {
 	calculatePlayerScore(player: MultiplayerDataUser): number {
 		let newScore = player.score;
 
-		if(player.mods == 24) {
+		if (player.mods == 24) {
 			newScore /= 1.12;
 		}
 
-		if(player.mods == 72) {
+		if (player.mods == 72) {
 			newScore /= 1.06;
 		}
 
@@ -26,17 +26,17 @@ export class TeamVsHiddenCalculation extends ScoreInterface {
 		newScore = Math.ceil(newScore);
 
 		// Just hidden
-		if(player.mods == 8) {
+		if (player.mods == 8) {
 			newScore *= 1.06;
 		}
 
 		// Hidden + Hardrock
-		if(player.mods == 24) {
+		if (player.mods == 24) {
 			newScore *= 1.18;
 		}
 
 		// Hidden + Doubletime
-		if(player.mods == 72) {
+		if (player.mods == 72) {
 			newScore *= 1.12;
 		}
 
@@ -48,8 +48,8 @@ export class TeamVsHiddenCalculation extends ScoreInterface {
 	calculateTeamOneScore() {
 		let teamScore = 0;
 
-		for (let i = 0; i < this.getTeamSize(); i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamRedUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;
@@ -58,8 +58,8 @@ export class TeamVsHiddenCalculation extends ScoreInterface {
 	calculateTeamTwoScore() {
 		let teamScore = 0;
 
-		for (let i = this.getTeamSize(); i < this.getTeamSize() * 2; i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamBlueUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;

--- a/src/app/models/score-calculation/calculation-types/three-cwc-score-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/three-cwc-score-calculation.ts
@@ -43,8 +43,8 @@ export class ThreeCwcScoreCalculation extends ScoreInterface {
 	calculateTeamOneScore() {
 		let teamScore = 0;
 
-		for (let i = 0; i < this.getTeamSize(); i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamRedUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;
@@ -53,8 +53,8 @@ export class ThreeCwcScoreCalculation extends ScoreInterface {
 	calculateTeamTwoScore() {
 		let teamScore = 0;
 
-		for (let i = this.getTeamSize(); i < this.getTeamSize() * 2; i++) {
-			teamScore += this.calculatePlayerScore(this.getUserBySlot(i));
+		for (const player of this.getTeamBlueUsers()) {
+			teamScore += this.calculatePlayerScore(player);
 		}
 
 		return teamScore;

--- a/src/app/models/store-multiplayer/multiplayer-data-user.ts
+++ b/src/app/models/store-multiplayer/multiplayer-data-user.ts
@@ -1,3 +1,8 @@
+export enum Team {
+	Blue = 1,
+	Red = 2
+}
+
 export class MultiplayerDataUser {
 	accuracy: number;
 	mods: number;
@@ -5,6 +10,7 @@ export class MultiplayerDataUser {
 	score: number;
 	user: number;
 	slot: number;
+	team: number;
 	caption: string;
 
 	constructor(init?: Partial<MultiplayerDataUser>) {
@@ -22,6 +28,7 @@ export class MultiplayerDataUser {
 			score: multiplayerDataUser.score,
 			user: multiplayerDataUser.user,
 			slot: multiplayerDataUser.slot,
+			team: multiplayerDataUser.team,
 			caption: multiplayerDataUser.caption
 		});
 	}

--- a/src/app/models/store-multiplayer/multiplayer-data.ts
+++ b/src/app/models/store-multiplayer/multiplayer-data.ts
@@ -1,5 +1,5 @@
 import { Mods } from '../osu-models/osu';
-import { MultiplayerDataUser } from './multiplayer-data-user';
+import { MultiplayerDataUser, Team } from './multiplayer-data-user';
 
 export class MultiplayerData {
 	game_id: number;
@@ -7,10 +7,14 @@ export class MultiplayerData {
 	mods: Mods;
 	team_one_score: number;
 	team_two_score: number;
+	teamRedPlayers: MultiplayerDataUser[];
+	teamBluePlayers: MultiplayerDataUser[];
 	private players: MultiplayerDataUser[];
 
 	constructor(init?: Partial<MultiplayerData>) {
 		this.players = [];
+		this.teamRedPlayers = [];
+		this.teamBluePlayers = [];
 
 		Object.assign(this, init);
 	}
@@ -27,6 +31,13 @@ export class MultiplayerData {
 		for (const player in multiplayerData.players) {
 			if (multiplayerData.players[player] != null) {
 				newMultiplayerData.players.push(MultiplayerDataUser.makeTrueCopy(multiplayerData.players[player]));
+
+				if (multiplayerData.players[player].team == Team.Red) {
+					newMultiplayerData.teamRedPlayers.push(multiplayerData.players[player]);
+				}
+				else if (multiplayerData.players[player].team == Team.Blue) {
+					newMultiplayerData.teamBluePlayers.push(multiplayerData.players[player]);
+				}
 			}
 		}
 

--- a/src/app/modules/lobby/components/lobby-view/lobby-view.component.html
+++ b/src/app/modules/lobby/components/lobby-view/lobby-view.component.html
@@ -155,7 +155,7 @@
 						</div>
 
 						<div *ngIf="match.team_two_score > match.team_one_score">
-							<h3><span class="blue-text">{{ selectedLobby.teamTwoName }}</span> has won.</h3><span class="red-text">{{ selectedLobby.teamOneName }}</span> score : {{ addDot(match.team_one_score, " ")}} | {{ addDot(match.team_two_score, " ") }} : score <span class="blue-text">{{ selectedLobby.teamTwoName }}</span> {{ addDot(match.team_two_score, " ") }} | Score difference: {{ addDot(match.team_two_score - match.team_one_score, " ") }}
+							<h3><span class="blue-text">{{ selectedLobby.teamTwoName }}</span> has won.</h3><span class="red-text">{{ selectedLobby.teamOneName }}</span> score : {{ addDot(match.team_one_score, " ")}} | {{ addDot(match.team_two_score, " ") }} : score <span class="blue-text">{{ selectedLobby.teamTwoName }}</span> | Score difference: {{ addDot(match.team_two_score - match.team_one_score, " ") }}
 						</div>
 					</div>
 				</div>

--- a/src/app/modules/lobby/components/lobby-view/lobby-view.component.html
+++ b/src/app/modules/lobby/components/lobby-view/lobby-view.component.html
@@ -60,7 +60,51 @@
 					<div class="team-scores">
 						<h4>{{ selectedLobby.teamOneName }}</h4>
 
-						<div class="score-table">
+						<!-- Doesnt use static slots, show users by what team they belong to -->
+						<div class="score-table" *ngIf="!selectedLobby.tournament.scoreInterface.usesStaticSlots()">
+							<div class="score" *ngFor="let player of match.teamRedPlayers">
+								<div class="column">
+									<div class="user">
+										{{ getUsernameFromUserId(player.user) }}
+									</div>
+
+									<div class="extra-spacing" *ngIf="player.passed == 0">
+										<s>Score: {{ player.score }}</s>
+									</div>
+
+									<div class="extra-spacing" *ngIf="player.passed == 1">
+										Score: {{ player.score }}
+									</div>
+								</div>
+
+								<div class="column">
+									<div class="extra-spacing mods">
+										<img *ngFor="let mod of getModsFromPlayer(player)" [src]="'assets/osu-mods/' + mod + '.png'" />
+									</div>
+
+									<s class="extra-spacing align-right" *ngIf="player.passed == 0">
+										{{ player.accuracy }}%
+									</s>
+
+									<div class="extra-spacing align-right" *ngIf="player.passed == 1">
+										{{ player.accuracy }}%
+									</div>
+								</div>
+							</div>
+
+							<div class="score">
+								<div class="column">
+									<b>Total score</b>
+								</div>
+
+								<div class="column">
+									{{ addDot(match.team_one_score, " ") }}
+								</div>
+							</div>
+						</div>
+
+						<!-- Uses static slots, show users by the given slots instead of actual teams -->
+						<div class="score-table" *ngIf="selectedLobby.tournament.scoreInterface.usesStaticSlots()">
 							<div class="score" *ngFor="let slot of selectedLobby.teamOneSlotArray">
 								<div class="column">
 									<div class="user">
@@ -78,7 +122,7 @@
 
 								<div class="column">
 									<div class="extra-spacing mods">
-										<img *ngFor="let mod of getMods(match, slot)" [src]="'assets/osu-mods/' + mod + '.png'" />
+										<img *ngFor="let mod of getModsBySlotId(match, slot)" [src]="'assets/osu-mods/' + mod + '.png'" />
 									</div>
 
 									<s class="extra-spacing align-right" *ngIf="match.getPlayer(slot).passed == 0">
@@ -106,7 +150,51 @@
 
 						<h4>{{ selectedLobby.teamTwoName }}</h4>
 
-						<div class="score-table">
+						<!-- Doesnt use static slots, show users by what team they belong to -->
+						<div class="score-table" *ngIf="!selectedLobby.tournament.scoreInterface.usesStaticSlots()">
+							<div class="score" *ngFor="let player of match.teamBluePlayers">
+								<div class="column">
+									<div class="user">
+										{{ getUsernameFromUserId(player.user) }}
+									</div>
+
+									<div class="extra-spacing" *ngIf="player.passed == 0">
+										<s>Score: {{ player.score }}</s>
+									</div>
+
+									<div class="extra-spacing" *ngIf="player.passed == 1">
+										Score: {{ player.score }}
+									</div>
+								</div>
+
+								<div class="column">
+									<div class="extra-spacing mods">
+										<img *ngFor="let mod of getModsFromPlayer(player)" [src]="'assets/osu-mods/' + mod + '.png'" />
+									</div>
+
+									<s class="extra-spacing align-right" *ngIf="player.passed == 0">
+										{{ player.accuracy }}%
+									</s>
+
+									<div class="extra-spacing align-right" *ngIf="player.passed == 1">
+										{{ player.accuracy }}%
+									</div>
+								</div>
+							</div>
+
+							<div class="score">
+								<div class="column">
+									<b>Total score</b>
+								</div>
+
+								<div class="column">
+									{{ addDot(match.team_one_score, " ") }}
+								</div>
+							</div>
+						</div>
+
+						<!-- Uses static slots, show users by the given slots instead of actual teams -->
+						<div class="score-table" *ngIf="selectedLobby.tournament.scoreInterface.usesStaticSlots()">
 							<div class="score" *ngFor="let slot of selectedLobby.teamTwoSlotArray">
 								<div class="column">
 									<div class="user">
@@ -124,7 +212,7 @@
 
 								<div class="column">
 									<div class="extra-spacing mods">
-										<img *ngFor="let mod of getMods(match, slot)" [src]="'assets/osu-mods/' + mod + '.png'" />
+										<img *ngFor="let mod of getModsBySlotId(match, slot)" [src]="'assets/osu-mods/' + mod + '.png'" />
 									</div>
 
 									<s class="extra-spacing align-right" *ngIf="match.getPlayer(slot).passed == 0">

--- a/src/app/modules/lobby/components/lobby-view/lobby-view.component.ts
+++ b/src/app/modules/lobby/components/lobby-view/lobby-view.component.ts
@@ -271,7 +271,7 @@ export class LobbyViewComponent implements OnInit {
 	 * @param match the MultiplayerData
 	 * @param slotId the slot you want the mods from
 	 */
-	getMods(match: MultiplayerData, slotId: number): string[] {
+	getModsBySlotId(match: MultiplayerData, slotId: number): string[] {
 		const user: MultiplayerDataUser = match.getPlayer(slotId);
 		const mods: string[] = [];
 
@@ -282,6 +282,24 @@ export class LobbyViewComponent implements OnInit {
 		}
 
 		return (user != undefined || user.mods != undefined) ? mods : [];
+	}
+
+	/**
+	 * Get the mods of the player in the given slot
+	 *
+	 * @param match the MultiplayerData
+	 * @param slotId the slot you want the mods from
+	 */
+	getModsFromPlayer(player: MultiplayerDataUser): string[] {
+		const mods: string[] = [];
+
+		const selectedMods = OsuHelper.getModsFromBit(player.mods);
+
+		for (const mod of selectedMods) {
+			mods.push(OsuHelper.getModAbbreviation(mod));
+		}
+
+		return (player != undefined || player.mods != undefined) ? mods : [];
 	}
 
 	/**

--- a/src/app/services/wy-multiplayer-lobbies.service.ts
+++ b/src/app/services/wy-multiplayer-lobbies.service.ts
@@ -214,12 +214,13 @@ export class WyMultiplayerLobbiesService {
 					}
 
 					const newMultiplayerDataUser = new MultiplayerDataUser({
-						user: currentScore.user_id,
-						score: currentScore.score,
+						user: +currentScore.user_id,
+						score: +currentScore.score,
 						accuracy: Calculations.getAccuracyOfScore(currentScore),
-						passed: currentScore.pass,
-						slot: currentScore.slot,
-						mods: currentScore.enabled_mods
+						passed: +currentScore.pass,
+						slot: +currentScore.slot,
+						mods: +currentScore.enabled_mods,
+						team: +currentScore.team
 					});
 
 					// Invalidate beatmaps that aren't part of the mappool
@@ -258,7 +259,6 @@ export class WyMultiplayerLobbiesService {
 
 				const calculate = new Calculate();
 				const scoreInterface = calculate.getScoreInterface(multiplayerLobby.tournament.scoreInterfaceIdentifier);
-
 				scoreInterface.addUserScores(multiplayerData.getPlayers());
 
 				if (scoreInterface.getTeamSize() == undefined || scoreInterface.getTeamSize() == null || scoreInterface.getTeamSize() == 0) {
@@ -271,7 +271,7 @@ export class WyMultiplayerLobbiesService {
 				}
 
 				// Provide the mod bracket to the interface
-				if (scoreInterface instanceof ThreeCwcScoreCalculation) {
+				if (scoreInterface instanceof ThreeCwcScoreCalculation || scoreInterface instanceof OMLScoreCalculation) {
 					let foundModBracket: WyModBracket;
 
 					for (const mappool of multiplayerLobby.tournament.mappools) {
@@ -289,28 +289,6 @@ export class WyMultiplayerLobbiesService {
 						scoreInterface.setModBracket(foundModBracket);
 					}
 				}
-
-				// Provide the mod bracket to the interface
-				if (scoreInterface instanceof OMLScoreCalculation) {
-					let foundModBracket: WyModBracket;
-
-					for (const mappool of multiplayerLobby.tournament.mappools) {
-						for (const modBracket of mappool.modBrackets) {
-							for (const beatmap of modBracket.beatmaps) {
-								if (beatmap.beatmapId == currentGame.beatmap_id) {
-									foundModBracket = modBracket;
-									break;
-								}
-							}
-						}
-					}
-
-					if (foundModBracket) {
-						scoreInterface.setModBracket(foundModBracket);
-					}
-				}
-
-				scoreInterface.addUserScores(multiplayerData.getPlayers());
 
 				multiplayerData.team_one_score = scoreInterface.calculateTeamOneScore();
 				multiplayerData.team_two_score = scoreInterface.calculateTeamTwoScore();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,14 +1499,14 @@
     minimatch "^3.0.4"
     plist "^3.0.4"
 
-"@es-joy/jsdoccomment@~0.22.1":
-  version "0.22.2"
-  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz#1c972f56a265ada7facbd0770a6caea6a391f5c8"
-  integrity sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==
+"@es-joy/jsdoccomment@~0.37.1":
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.37.1.tgz#fa32a41ba12097452693343e09ad4d26d157aedd"
+  integrity sha512-5vxWJ1gEkEF0yRd0O+uK6dHJf7adrxwQSX8PuRiPfFSAbNLnY0ZJfXaZucoz14Jj2N11xn2DnlEPwWRpYpvRjg==
   dependencies:
     comment-parser "1.3.1"
-    esquery "^1.4.0"
-    jsdoc-type-pratt-parser "~2.2.5"
+    esquery "^1.5.0"
+    jsdoc-type-pratt-parser "~4.0.0"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -2683,6 +2683,11 @@ app-root-path@^3.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+are-docs-informative@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
+  integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
 
 are-we-there-yet@^3.0.0:
   version "3.0.1"
@@ -4721,18 +4726,18 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-plugin-jsdoc@38.1.6:
-  version "38.1.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz#7dfa2a6d38f550935c6a3668a1fc5a05b19e4069"
-  integrity sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==
+eslint-plugin-jsdoc@^43.1.1:
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.1.1.tgz#fc72ba21597cc99b1a0dc988aebb9bb57d0ec492"
+  integrity sha512-J2kjjsJ5vBXSyNzqJhceeSGTAgVgZHcPSJKo3vD4tNjUdfky98rR2VfZUDsS1GKL6isyVa8GWvr+Az7Vyg2HXA==
   dependencies:
-    "@es-joy/jsdoccomment" "~0.22.1"
+    "@es-joy/jsdoccomment" "~0.37.1"
+    are-docs-informative "^0.0.2"
     comment-parser "1.3.1"
     debug "^4.3.4"
     escape-string-regexp "^4.0.0"
-    esquery "^1.4.0"
-    regextras "^0.8.0"
-    semver "^7.3.5"
+    esquery "^1.5.0"
+    semver "^7.5.0"
     spdx-expression-parse "^3.0.1"
 
 eslint-plugin-prefer-arrow@1.2.3:
@@ -4841,6 +4846,13 @@ esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esquery@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
   dependencies:
     estraverse "^5.1.0"
 
@@ -6346,10 +6358,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
 
-jsdoc-type-pratt-parser@~2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz#c9f93afac7ee4b5ed4432fe3f09f7d36b05ed0ff"
-  integrity sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==
+jsdoc-type-pratt-parser@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz#136f0571a99c184d84ec84662c45c29ceff71114"
+  integrity sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -8400,11 +8412,6 @@ regexpu-core@^5.2.1:
     unicode-match-property-ecmascript "^2.0.0"
     unicode-match-property-value-ecmascript "^2.1.0"
 
-regextras@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/regextras/-/regextras-0.8.0.tgz#ec0f99853d4912839321172f608b544814b02217"
-  integrity sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==
-
 registry-auth-token@^4.0.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.2.tgz#f02d49c3668884612ca031419491a13539e21fac"
@@ -8750,6 +8757,13 @@ semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semve
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
+  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
Scores were being calculated by which slot the players were in. With this it will no longer check (except for AxS) in which slot the players are, but rather which team they are on. This will minimize the risk of people not being in the correct slots and such