### PR TITLE
Catch The Magic 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wyreferee",
-	"version": "6.5.12",
+	"version": "6.5.13",
 	"description": "Referee client",
 	"author": {
 		"name": "Wesley"

--- a/src/app/components/dialogs/send-beatmap-result/send-beatmap-result.component.ts
+++ b/src/app/components/dialogs/send-beatmap-result/send-beatmap-result.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ISendBeatmapResultDialogData } from 'app/interfaces/i-send-beatmap-result-dialog-data';
+import { CTMCalculation } from 'app/models/score-calculation/calculation-types/ctm-calculation';
 import { MultiplayerData } from 'app/models/store-multiplayer/multiplayer-data';
 import { CacheService } from 'app/services/cache.service';
 import { IrcService } from 'app/services/irc.service';
@@ -56,6 +57,20 @@ export class SendBeatmapResultComponent implements OnInit {
 				'{{\\s{0,}nextPick\\s{0,}}}': this.data.multiplayerLobby.getNextPick(),
 				'{{\\s{0,}matchWinner\\s{0,}}}': this.data.multiplayerLobby.teamHasWon()
 			};
+
+			if (this.data.multiplayerLobby.tournament.scoreInterface instanceof CTMCalculation) {
+				replaceWords['{{\\s{0,}teamOneHitpoints\\s{0,}}}'] = this.data.multiplayerLobby.teamOneHealth;
+				replaceWords['{{\\s{0,}teamTwoHitpoints\\s{0,}}}'] = this.data.multiplayerLobby.teamTwoHealth;
+
+				for (const modBracket of this.data.multiplayerLobby.mappool.modBrackets) {
+					for (const beatmap of modBracket.beatmaps) {
+						if (beatmap.beatmapId == match.beatmap_id) {
+							replaceWords['{{\\s{0,}damageDealt\\s{0,}}}'] = beatmap.damageAmount;
+							break;
+						}
+					}
+				}
+			}
 
 			for (const beatmapResultMessage of this.data.multiplayerLobby.tournament.beatmapResultMessages) {
 				let finalMessage = beatmapResultMessage.message;

--- a/src/app/models/lobby.ts
+++ b/src/app/models/lobby.ts
@@ -49,6 +49,13 @@ export class Lobby {
 	teamOneOverwriteScore: number;
 	teamTwoOverwriteScore: number;
 
+	// CTM health
+	teamOneHealth: number;
+	teamTwoHealth: number;
+
+	teamOneOverwriteHealth: number;
+	teamTwoOverwriteHealth: number;
+
 	teamOneBans: number[];
 	teamTwoBans: number[];
 
@@ -91,6 +98,12 @@ export class Lobby {
 		this.teamOneOverwriteScore = 0;
 		this.teamTwoOverwriteScore = 0;
 
+		this.teamOneHealth = 50;
+		this.teamTwoHealth = 50;
+
+		this.teamOneOverwriteHealth = 0;
+		this.teamTwoOverwriteHealth = 0;
+
 		this.ircConnected = false;
 
 		this.isQualifierLobby = false;
@@ -124,6 +137,10 @@ export class Lobby {
 			teamTwoScore: lobby.teamTwoScore,
 			teamOneOverwriteScore: !isNaN(lobby.teamOneOverwriteScore) ? lobby.teamOneOverwriteScore : 0,
 			teamTwoOverwriteScore: !isNaN(lobby.teamTwoOverwriteScore) ? lobby.teamTwoOverwriteScore : 0,
+			teamOneHealth: lobby.teamOneHealth,
+			teamTwoHealth: lobby.teamTwoHealth,
+			teamOneOverwriteHealth: !isNaN(lobby.teamOneOverwriteHealth) ? lobby.teamOneOverwriteScore : 0,
+			teamTwoOverwriteHealth: !isNaN(lobby.teamTwoOverwriteHealth) ? lobby.teamTwoOverwriteScore : 0,
 			teamOneBans: lobby.teamOneBans,
 			teamTwoBans: lobby.teamTwoBans,
 			teamOnePicks: lobby.teamOnePicks,
@@ -527,6 +544,20 @@ export class Lobby {
 	 */
 	getTeamTwoScore(): number {
 		return this.teamTwoScore + this.teamTwoOverwriteScore;
+	}
+
+	/**
+	 * Calculate the health of team one with health overwriting
+	 */
+	getTeamOneHealth(): number {
+		return this.teamOneHealth + this.teamOneOverwriteHealth;
+	}
+
+	/**
+	 * Calculate the health of team two with health overwriting
+	 */
+	getTeamTwoHealth(): number {
+		return this.teamTwoHealth + this.teamTwoOverwriteHealth;
 	}
 
 	/**

--- a/src/app/models/lobby.ts
+++ b/src/app/models/lobby.ts
@@ -98,8 +98,8 @@ export class Lobby {
 		this.teamOneOverwriteScore = 0;
 		this.teamTwoOverwriteScore = 0;
 
-		this.teamOneHealth = 50;
-		this.teamTwoHealth = 50;
+		this.teamOneHealth = 0;
+		this.teamTwoHealth = 0;
 
 		this.teamOneOverwriteHealth = 0;
 		this.teamTwoOverwriteHealth = 0;

--- a/src/app/models/score-calculation/calculate.ts
+++ b/src/app/models/score-calculation/calculate.ts
@@ -3,6 +3,7 @@ import { TeamVsCalculation } from './calculation-types/team-vs-calculation';
 import { AxSCalculation } from './calculation-types/axs-calculation';
 import { ThreeCwcScoreCalculation } from './calculation-types/three-cwc-score-calculation';
 import { OMLScoreCalculation } from './calculation-types/oml-score-calculation';
+import { CTMCalculation } from './calculation-types/ctm-calculation';
 
 export class Calculate {
 	private scoreInterfaces: ScoreInterface[];
@@ -14,6 +15,7 @@ export class Calculate {
 		this.addScoreInterface(new AxSCalculation('AxS', 3));
 		this.addScoreInterface(new ThreeCwcScoreCalculation('osu!catch 3 Digit World Cup', 3));
 		this.addScoreInterface(new OMLScoreCalculation('osu!catch Master League', 2));
+		this.addScoreInterface(new CTMCalculation('CTM4', 3));
 	}
 
 	/**

--- a/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
@@ -1,0 +1,35 @@
+import { ScoreInterface } from './score-interface';
+import { MultiplayerDataUser } from '../../store-multiplayer/multiplayer-data-user';
+
+export class CTMCalculation extends ScoreInterface {
+	constructor(identifier: string, teamSize: number) {
+		super(identifier);
+
+		this.setTeamSize(teamSize);
+		this.setDescription('The score calculation for Catch The Magic 4.');
+	}
+
+	calculatePlayerScore(player: MultiplayerDataUser): number {
+		return Number(player != null ? player.passed == 1 ? player.score : 0 : 0);
+	}
+
+	calculateTeamOneScore() {
+		let teamScore = 0;
+
+		for (const player of this.getTeamRedUsers()) {
+			teamScore += this.calculatePlayerScore(player);
+		}
+
+		return teamScore;
+	}
+
+	calculateTeamTwoScore() {
+		let teamScore = 0;
+
+		for (const player of this.getTeamBlueUsers()) {
+			teamScore += this.calculatePlayerScore(player);
+		}
+
+		return teamScore;
+	}
+}

--- a/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
@@ -1,15 +1,62 @@
 import { ScoreInterface } from './score-interface';
 import { MultiplayerDataUser } from '../../store-multiplayer/multiplayer-data-user';
+import { Mods } from 'app/models/osu-models/osu';
 
 export class CTMCalculation extends ScoreInterface {
+	private readonly MAX_BONUS_SCORE = 150000;
+
+	private readonly EASY_ONLY_BONUS_SCORE = 500000;
+	private readonly EASY_BONUS_SCORE = 25000;
+	private readonly HARDROCK_BONUS_SCORE = 50000;
+	private readonly DOUBLETIME_BONUS_SCORE = 75000;
+	private readonly FLASHLIGHT_BONUS_SCORE = 100000;
+	private readonly SUDDEN_DEATH_BONUS_SCORE = 150000;
+
+	private teamOneBonusScore: number;
+	private teamTwoBonusScore: number;
+
 	constructor(identifier: string, teamSize: number) {
 		super(identifier);
 
 		this.setTeamSize(teamSize);
 		this.setDescription('The score calculation for Catch The Magic 4.');
+
+		this.teamOneBonusScore = 0;
+		this.teamTwoBonusScore = 0;
 	}
 
-	calculatePlayerScore(player: MultiplayerDataUser): number {
+	calculatePlayerScore(player: MultiplayerDataUser, team: number): number {
+		let easyOnlyWasUsed = false;
+
+		if ((player.mods & Mods.Easy) == player.mods || (player.mods & (Mods.Easy | Mods.NoFail)) == player.mods) {
+			this.addTeamBonusScore(this.EASY_BONUS_SCORE, team);
+			easyOnlyWasUsed = true;
+		}
+
+		if (player.mods & Mods.Easy && easyOnlyWasUsed == false) {
+			this.addTeamBonusScore(this.EASY_BONUS_SCORE, team);
+		}
+
+		if (player.mods & Mods.HardRock) {
+			this.addTeamBonusScore(this.HARDROCK_BONUS_SCORE, team);
+		}
+
+		if (player.mods & Mods.DoubleTime) {
+			this.addTeamBonusScore(this.DOUBLETIME_BONUS_SCORE, team);
+		}
+
+		if (player.mods & Mods.Flashlight) {
+			this.addTeamBonusScore(this.FLASHLIGHT_BONUS_SCORE, team);
+		}
+
+		if (player.mods & Mods.SuddenDeath) {
+			this.addTeamBonusScore(this.SUDDEN_DEATH_BONUS_SCORE, team);
+		}
+
+		if (easyOnlyWasUsed == true) {
+			player.score += this.EASY_ONLY_BONUS_SCORE;
+		}
+
 		return Number(player != null ? player.passed == 1 ? player.score : 0 : 0);
 	}
 
@@ -17,8 +64,10 @@ export class CTMCalculation extends ScoreInterface {
 		let teamScore = 0;
 
 		for (const player of this.getTeamRedUsers()) {
-			teamScore += this.calculatePlayerScore(player);
+			teamScore += this.calculatePlayerScore(player, 1);
 		}
+
+		teamScore += this.getBonusScore(1);
 
 		return teamScore;
 	}
@@ -27,9 +76,35 @@ export class CTMCalculation extends ScoreInterface {
 		let teamScore = 0;
 
 		for (const player of this.getTeamBlueUsers()) {
-			teamScore += this.calculatePlayerScore(player);
+			teamScore += this.calculatePlayerScore(player, 2);
 		}
 
+		teamScore += this.getBonusScore(2);
+
 		return teamScore;
+	}
+
+	/**
+	 * Add bonus score to the team's bonus score variable
+	 *
+	 * @param score the score to add to the team's bonus score
+	 * @param team the team to add the bonus score to
+	 */
+	private addTeamBonusScore(score: number, team: number) {
+		if (team == 1) {
+			this.teamOneBonusScore += score;
+		}
+		else if (team == 2) {
+			this.teamTwoBonusScore += score;
+		}
+	}
+
+	/**
+	 * Get the bonus score for the given team, this caps at the amount MAX_BONUS_SCORE is set to
+	 *
+	 * @param team the team to get the bonus score from
+	 */
+	private getBonusScore(team: number) {
+		return Math.min(team == 1 ? this.teamOneBonusScore : this.teamTwoBonusScore, this.MAX_BONUS_SCORE);
 	}
 }

--- a/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
@@ -1,8 +1,10 @@
 import { ScoreInterface } from './score-interface';
 import { MultiplayerDataUser } from '../../store-multiplayer/multiplayer-data-user';
 import { Mods } from 'app/models/osu-models/osu';
+import { WyModBracketMap } from 'app/models/wytournament/mappool/wy-mod-bracket-map';
 
 export class CTMCalculation extends ScoreInterface {
+	private readonly ADD_BONUS_SCORE_FOR_DAMAGE_AMOUNT = [6, 8];
 	private readonly MAX_BONUS_SCORE = 150000;
 
 	private readonly EASY_BONUS_SCORE = 525000;
@@ -16,6 +18,8 @@ export class CTMCalculation extends ScoreInterface {
 
 	private teamOneUsedEasy: boolean;
 	private teamTwoUsedEasy: boolean;
+
+	private beatmap: WyModBracketMap;
 
 	constructor(identifier: string, teamSize: number) {
 		super(identifier);
@@ -68,7 +72,10 @@ export class CTMCalculation extends ScoreInterface {
 			teamScore += this.calculatePlayerScore(player, 1);
 		}
 
-		teamScore += this.getBonusScore(1);
+		// Only add bonus score when the the proper damageAmount is used
+		if (this.ADD_BONUS_SCORE_FOR_DAMAGE_AMOUNT.includes(this.beatmap.damageAmount)) {
+			teamScore += this.getBonusScore(1);
+		}
 
 		return teamScore;
 	}
@@ -80,9 +87,22 @@ export class CTMCalculation extends ScoreInterface {
 			teamScore += this.calculatePlayerScore(player, 2);
 		}
 
-		teamScore += this.getBonusScore(2);
+		// Only add bonus score when the the proper damageAmount is used
+		if (this.ADD_BONUS_SCORE_FOR_DAMAGE_AMOUNT.includes(this.beatmap.damageAmount)) {
+			teamScore += this.getBonusScore(2);
+		}
+
 
 		return teamScore;
+	}
+
+	/**
+	 * Set the beatmap so we can use the damageAmount
+	 *
+	 * @param beatmap the beatmap to use for the calculation
+	 */
+	setBeatmap(beatmap: WyModBracketMap) {
+		this.beatmap = beatmap;
 	}
 
 	/**

--- a/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
+++ b/src/app/models/score-calculation/calculation-types/ctm-calculation.ts
@@ -5,8 +5,7 @@ import { Mods } from 'app/models/osu-models/osu';
 export class CTMCalculation extends ScoreInterface {
 	private readonly MAX_BONUS_SCORE = 150000;
 
-	private readonly EASY_ONLY_BONUS_SCORE = 500000;
-	private readonly EASY_BONUS_SCORE = 25000;
+	private readonly EASY_BONUS_SCORE = 525000;
 	private readonly HARDROCK_BONUS_SCORE = 50000;
 	private readonly DOUBLETIME_BONUS_SCORE = 75000;
 	private readonly FLASHLIGHT_BONUS_SCORE = 100000;
@@ -14,6 +13,9 @@ export class CTMCalculation extends ScoreInterface {
 
 	private teamOneBonusScore: number;
 	private teamTwoBonusScore: number;
+
+	private teamOneUsedEasy: boolean;
+	private teamTwoUsedEasy: boolean;
 
 	constructor(identifier: string, teamSize: number) {
 		super(identifier);
@@ -23,18 +25,21 @@ export class CTMCalculation extends ScoreInterface {
 
 		this.teamOneBonusScore = 0;
 		this.teamTwoBonusScore = 0;
+
+		this.teamOneUsedEasy = false;
+		this.teamTwoUsedEasy = false;
 	}
 
 	calculatePlayerScore(player: MultiplayerDataUser, team: number): number {
-		let easyOnlyWasUsed = false;
-
-		if ((player.mods & Mods.Easy) == player.mods || (player.mods & (Mods.Easy | Mods.NoFail)) == player.mods) {
+		if (player.mods & Mods.Easy) {
 			this.addTeamBonusScore(this.EASY_BONUS_SCORE, team);
-			easyOnlyWasUsed = true;
-		}
 
-		if (player.mods & Mods.Easy && easyOnlyWasUsed == false) {
-			this.addTeamBonusScore(this.EASY_BONUS_SCORE, team);
+			if (team == 1) {
+				this.teamOneUsedEasy = true;
+			}
+			else if (team == 2) {
+				this.teamTwoUsedEasy = true;
+			}
 		}
 
 		if (player.mods & Mods.HardRock) {
@@ -51,10 +56,6 @@ export class CTMCalculation extends ScoreInterface {
 
 		if (player.mods & Mods.SuddenDeath) {
 			this.addTeamBonusScore(this.SUDDEN_DEATH_BONUS_SCORE, team);
-		}
-
-		if (easyOnlyWasUsed == true) {
-			player.score += this.EASY_ONLY_BONUS_SCORE;
 		}
 
 		return Number(player != null ? player.passed == 1 ? player.score : 0 : 0);
@@ -105,6 +106,7 @@ export class CTMCalculation extends ScoreInterface {
 	 * @param team the team to get the bonus score from
 	 */
 	private getBonusScore(team: number) {
-		return Math.min(team == 1 ? this.teamOneBonusScore : this.teamTwoBonusScore, this.MAX_BONUS_SCORE);
+		const usedEasy = team == 1 ? this.teamOneUsedEasy : this.teamTwoUsedEasy;
+		return usedEasy ? this.EASY_BONUS_SCORE : Math.min(team == 1 ? this.teamOneBonusScore : this.teamTwoBonusScore, this.MAX_BONUS_SCORE);
 	}
 }

--- a/src/app/models/score-calculation/calculation-types/score-interface.ts
+++ b/src/app/models/score-calculation/calculation-types/score-interface.ts
@@ -191,9 +191,10 @@ export abstract class ScoreInterface {
 	 * Calculate the score of the given player
 	 *
 	 * @param player the player object to use the score calculations with
+	 * @param team the team the player belongs to
 	 * @returns the score of the player
 	 */
-	public abstract calculatePlayerScore(player: MultiplayerDataUser): number;
+	public abstract calculatePlayerScore(player: MultiplayerDataUser, team?: number): number;
 
 	/**
 	 * Calculate the final score of team one

--- a/src/app/models/store-multiplayer/multiplayer-data.ts
+++ b/src/app/models/store-multiplayer/multiplayer-data.ts
@@ -7,6 +7,8 @@ export class MultiplayerData {
 	mods: Mods;
 	team_one_score: number;
 	team_two_score: number;
+	team_one_health: number;
+	team_two_health: number;
 	teamRedPlayers: MultiplayerDataUser[];
 	teamBluePlayers: MultiplayerDataUser[];
 	private players: MultiplayerDataUser[];
@@ -25,7 +27,9 @@ export class MultiplayerData {
 			beatmap_id: multiplayerData.beatmap_id,
 			mods: multiplayerData.mods,
 			team_one_score: multiplayerData.team_one_score,
-			team_two_score: multiplayerData.team_two_score
+			team_two_score: multiplayerData.team_two_score,
+			team_one_health: multiplayerData.team_one_health,
+			team_two_health: multiplayerData.team_two_health
 		});
 
 		for (const player in multiplayerData.players) {

--- a/src/app/models/wytournament/mappool/wy-mappool.ts
+++ b/src/app/models/wytournament/mappool/wy-mappool.ts
@@ -15,7 +15,8 @@ export enum MappoolType {
 	Normal = 0,
 	AxS = 1,
 	MysteryTournament = 2,
-	RNGTournament = 3
+	RNGTournament = 3,
+	CTMTournament = 4
 }
 
 export class WyMappool {

--- a/src/app/models/wytournament/mappool/wy-mod-bracket-map.ts
+++ b/src/app/models/wytournament/mappool/wy-mod-bracket-map.ts
@@ -11,6 +11,7 @@ export class WyModBracketMap {
 	beatmapUrl: string;
 
 	modifier: number;
+	damageAmount: number;
 	modCategory: WyModCategory;
 	gamemodeId: number;
 
@@ -36,6 +37,7 @@ export class WyModBracketMap {
 			beatmapName: modBracketMap.beatmapName,
 			beatmapUrl: modBracketMap.beatmapUrl,
 			modifier: modBracketMap.modifier,
+			damageAmount: modBracketMap.damageAmount,
 			modCategory: modBracketMap.modCategory != undefined ? WyModCategory.makeTrueCopy(modBracketMap.modCategory) : null,
 			gamemodeId: modBracketMap.gamemodeId,
 			picked: modBracketMap.picked,

--- a/src/app/models/wytournament/wy-stage.ts
+++ b/src/app/models/wytournament/wy-stage.ts
@@ -2,6 +2,7 @@ export class WyStage {
 	id: string;
 	name: string;
 	index: number;
+	hitpoints: number;
 	bestOf: number;
 
 	constructor(init?: Partial<WyStage>) {
@@ -12,6 +13,7 @@ export class WyStage {
 		return new WyStage({
 			id: stage.id,
 			name: stage.name,
+			hitpoints: stage.hitpoints,
 			bestOf: stage.bestOf
 		});
 	}

--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -61,7 +61,8 @@
 	<div class="chat-content">
 		<div class="chat-container">
 			<div class="match-header" *ngIf="(selectedChannel != null && selectedChannel.name.startsWith('#mp_')) && this.selectedLobby != null && selectedLobby.isQualifierLobby == false">
-				<div class="match-header-center">
+				<!-- The mappool is for any tournament that is NOT Catch The Magic -->
+				<div class="match-header-center" *ngIf="selectedLobby.mappool.type != 4">
 					<div class="match-information">
 						<div class="team-one">
 							<div class="team-name red">
@@ -84,6 +85,45 @@
 
 							<div class="circles" matTooltip="Left click to increase the score, Right click to decrease the score, Middle mouse to reset to original" (mouseup)="$event.which == 2 ? adjustScore(2, 'middle') : $event.which == 3 ? adjustScore(2, 'right') : adjustScore(2, 'left')">
 								<div class="circle blue" [ngClass]="{ 'active': score <= teamTwoScore }" *ngFor="let score of selectedLobby.getMaxMatchPointsForIrcHeader()"></div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- The mappool is for Catch The Magic -->
+				<div class="match-header-center" *ngIf="selectedLobby.mappool.type == 4">
+					<div class="match-information">
+						<div class="team-one">
+							<div class="team-name red">
+								{{ selectedLobby.teamOneName }}
+							</div>
+
+							<div class="heart-container" matTooltip="Left click to increase the hitpoints, Right click to decrease the hitpoints, Middle mouse to reset to original" (mouseup)="$event.which == 2 ? adjustHealth(1, 'middle') : $event.which == 3 ? adjustHealth(1, 'right') : adjustHealth(1, 'left')">
+								<span class="heart-text">{{ selectedLobby.getTeamOneHealth() }}</span>
+
+								<svg class="heart" viewBox="0 0 32 29.6">
+									<path d="M23.6,0c-3.4,0-6.3,2.7-7.6,5.6C14.7,2.7,11.8,0,8.4,0C3.8,0,0,3.8,0,8.4c0,9.4,9.5,11.9,16,21.2
+										c6.1-9.3,16-12.1,16-21.2C32,3.8,28.2,0,23.6,0z"/>
+								</svg>
+							</div>
+						</div>
+
+						<div class="middle">
+							vs
+						</div>
+
+						<div class="team-two">
+							<div class="team-name blue">
+								{{ selectedLobby.teamTwoName }}
+							</div>
+
+							<div class="heart-container" matTooltip="Left click to increase the hitpoints, Right click to decrease the hitpoints, Middle mouse to reset to original" (mouseup)="$event.which == 2 ? adjustHealth(2, 'middle') : $event.which == 3 ? adjustHealth(2, 'right') : adjustHealth(2, 'left')">
+								<span class="heart-text">{{ selectedLobby.getTeamTwoHealth() }}</span>
+
+								<svg class="heart" viewBox="0 0 32 29.6">
+									<path d="M23.6,0c-3.4,0-6.3,2.7-7.6,5.6C14.7,2.7,11.8,0,8.4,0C3.8,0,0,3.8,0,8.4c0,9.4,9.5,11.9,16,21.2
+										c6.1-9.3,16-12.1,16-21.2C32,3.8,28.2,0,23.6,0z"/>
+								</svg>
 							</div>
 						</div>
 					</div>

--- a/src/app/modules/irc/components/irc/irc.component.scss
+++ b/src/app/modules/irc/components/irc/irc.component.scss
@@ -300,6 +300,29 @@ $hyperlink-background-color: #2b4576;
 									cursor: pointer;
 								}
 							}
+
+							.heart-container {
+								display: flex;
+								align-items: center;
+								justify-content: center;
+
+								margin-top: 5px;
+								user-select: none;
+
+								.heart-text {
+									position: absolute;
+									margin-bottom: 5px;
+								}
+
+								.heart {
+									height: 50px;
+									fill: #ff0000;
+								}
+
+								&:hover {
+									cursor: pointer;
+								}
+							}
 						}
 
 						.middle {

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -248,7 +248,9 @@ export class IrcComponent implements OnInit {
 			this.tiebreaker = this.selectedLobby.getTiebreaker();
 			this.hasWon = this.selectedLobby.teamHasWon();
 
-			this.initializeQualifierTeams();
+			if (this.selectedLobby.isQualifierLobby) {
+				this.initializeQualifierTeams();
+			}
 		}
 
 		// Scroll to the bottom - delay it by 500 ms or do it instantly
@@ -979,8 +981,6 @@ export class IrcComponent implements OnInit {
 		this.qualifierTeams = [];
 
 		const qualifierIdentifier = this.selectedLobby.description.substring(this.qualifierPrefix.length).trim();
-
-		console.log(qualifierIdentifier);
 
 		this.tournamentService.getWyBinQualifierLobbyTeams(this.selectedLobby.tournament.wyBinTournamentId, qualifierIdentifier).subscribe(teams => {
 			for (const team in teams) {

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -74,6 +74,10 @@ export class IrcComponent implements OnInit {
 
 	teamOneScore = 0;
 	teamTwoScore = 0;
+
+	teamOneHealth = 0;
+	teamTwoHealth = 0;
+
 	nextPick: string = null;
 	matchpoint: string = null;
 	tiebreaker = false;
@@ -237,6 +241,8 @@ export class IrcComponent implements OnInit {
 		if (this.selectedLobby != undefined) {
 			this.teamOneScore = this.selectedLobby.getTeamOneScore();
 			this.teamTwoScore = this.selectedLobby.getTeamTwoScore();
+			this.teamOneHealth = this.selectedLobby.getTeamOneHealth();
+			this.teamTwoHealth = this.selectedLobby.getTeamOneHealth();
 			this.nextPick = this.selectedLobby.getNextPick();
 			this.matchpoint = this.selectedLobby.getMatchPoint();
 			this.tiebreaker = this.selectedLobby.getTiebreaker();
@@ -556,6 +562,8 @@ export class IrcComponent implements OnInit {
 		if (!this.selectedLobby.ircChannel.isPublicChannel && !this.selectedLobby.ircChannel.isPrivateChannel) {
 			this.teamOneScore = multiplayerLobby.getTeamOneScore();
 			this.teamTwoScore = multiplayerLobby.getTeamTwoScore();
+			this.teamOneHealth = this.selectedLobby.getTeamOneHealth();
+			this.teamTwoHealth = this.selectedLobby.getTeamOneHealth();
 			this.nextPick = multiplayerLobby.getNextPick();
 			this.matchpoint = multiplayerLobby.getMatchPoint();
 			this.tiebreaker = multiplayerLobby.getTiebreaker();
@@ -921,6 +929,42 @@ export class IrcComponent implements OnInit {
 			}
 			else if (team == 2) {
 				this.selectedLobby.teamTwoOverwriteScore = 0;
+			}
+		}
+
+		this.multiplayerLobbies.updateMultiplayerLobby(this.selectedLobby);
+		this.refreshIrcHeader(this.selectedLobby);
+	}
+
+	/**
+	 * Adjust the health for the selected team
+	 *
+	 * @param team the team to adjust the health for
+	 * @param mouseClick left or right to increase or decrease
+	 */
+	adjustHealth(team: number, mouseClick: string) {
+		if (mouseClick == 'left') {
+			if (team == 1) {
+				this.selectedLobby.teamOneOverwriteHealth++;
+			}
+			else if (team == 2) {
+				this.selectedLobby.teamTwoOverwriteHealth++;
+			}
+		}
+		else if (mouseClick == 'right') {
+			if (team == 1) {
+				this.selectedLobby.teamOneOverwriteHealth--;
+			}
+			else if (team == 2) {
+				this.selectedLobby.teamTwoOverwriteHealth--;
+			}
+		}
+		else if (mouseClick == 'middle') {
+			if (team == 1) {
+				this.selectedLobby.teamOneOverwriteHealth = 0;
+			}
+			else if (team == 2) {
+				this.selectedLobby.teamTwoOverwriteHealth = 0;
 			}
 		}
 

--- a/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
+++ b/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
@@ -213,6 +213,9 @@ export class CreateLobbyComponent implements OnInit {
 						lobby.selectedStage = stage;
 						lobby.bestOf = stage.bestOf;
 
+						lobby.teamOneHealth = Number(stage.hitpoints);
+						lobby.teamTwoHealth = Number(stage.hitpoints);
+
 						break;
 					}
 				}

--- a/src/app/modules/tournament-management/components/mappool/mappool/mappool.component.html
+++ b/src/app/modules/tournament-management/components/mappool/mappool/mappool.component.html
@@ -28,6 +28,7 @@
 					<mat-option [value]="1">AxS</mat-option>
 					<mat-option [value]="2">Mystery tournament</mat-option>
 					<mat-option [value]="3">RNG tournament</mat-option>
+					<mat-option [value]="4">CTM tournament</mat-option>
 				</mat-select>
 
 				<mat-error *ngIf="validationForm.get('mappool-' + mappool.index + '-type').errors && (validationForm.get('mappool-' + mappool.index + '-type').touched || validationForm.get('mappool-' + mappool.index + '-type').dirty)">

--- a/src/app/modules/tournament-management/components/mappool/mappool/mappool.component.ts
+++ b/src/app/modules/tournament-management/components/mappool/mappool/mappool.component.ts
@@ -43,10 +43,18 @@ export class MappoolComponent implements OnInit {
 				}
 			}
 		}
+		else if (event.value == MappoolType.CTMTournament) {
+			for (const modBracket of this.mappool.modBrackets) {
+				for (const beatmap of modBracket.beatmaps) {
+					this.validationForm.addControl(`mappool-${this.mappool.index}-mod-bracket-${modBracket.index}-beatmap-${beatmap.index}-damage-amount`, new FormControl(beatmap.modifier, Validators.required));
+				}
+			}
+		}
 		else {
 			for (const modBracket of this.mappool.modBrackets) {
 				for (const beatmap of modBracket.beatmaps) {
 					this.validationForm.removeControl(`mappool-${this.mappool.index}-mod-bracket-${modBracket.index}-beatmap-${beatmap.index}-modifier`);
+					this.validationForm.removeControl(`mappool-${this.mappool.index}-mod-bracket-${modBracket.index}-beatmap-${beatmap.index}-damage-amount`);
 				}
 			}
 		}

--- a/src/app/modules/tournament-management/components/mappool/mod-bracket/mod-bracket.component.html
+++ b/src/app/modules/tournament-management/components/mappool/mod-bracket/mod-bracket.component.html
@@ -98,12 +98,25 @@
 								</mat-form-field>
 							</div>
 
+							<!-- AxS modifier -->
 							<div class="column" *ngIf="mappool.type == 1">
 								<mat-form-field class="full-width">
 									<mat-label>Modifier</mat-label>
 									<input matInput [formControlName]="'mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-modifier'" [(ngModel)]="beatmap.modifier" />
 
 									<mat-error *ngIf="validationForm.get('mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-modifier').errors && (validationForm.get('mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-modifier').touched || validationForm.get('mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-modifier').dirty)">
+										This field is required
+									</mat-error>
+								</mat-form-field>
+							</div>
+
+							<!-- CTM damage amount -->
+							<div class="column" *ngIf="mappool.type == 4">
+								<mat-form-field class="full-width">
+									<mat-label>Damage amount</mat-label>
+									<input matInput [formControlName]="'mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-damage-amount'" [(ngModel)]="beatmap.damageAmount" />
+
+									<mat-error *ngIf="validationForm.get('mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-damage-amount').errors && (validationForm.get('mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-damage-amount').touched || validationForm.get('mappool-' + this.mappool.index + '-mod-bracket-' + modBracket.index + '-beatmap-' + beatmap.index + '-damage-amount').dirty)">
 										This field is required
 									</mat-error>
 								</mat-form-field>

--- a/src/app/modules/tournament-management/components/mappool/mod-bracket/mod-bracket.component.ts
+++ b/src/app/modules/tournament-management/components/mappool/mod-bracket/mod-bracket.component.ts
@@ -116,6 +116,12 @@ export class ModBracketComponent implements OnInit {
 					}
 				}
 
+				if (this.mappool.type == MappoolType.CTMTournament) {
+					for (const beatmap in modBracket.beatmaps) {
+						this.validationForm.removeControl(`mappool-${this.mappool.index}-mod-bracket-${modBracket.index}-beatmap-${modBracket.beatmaps[beatmap].index}-damage-amount`);
+					}
+				}
+
 				this.toastService.addToast(`Successfully removed "${modBracket.name}" from the mappool.`);
 			}
 		});
@@ -172,6 +178,10 @@ export class ModBracketComponent implements OnInit {
 		if (this.mappool.type == MappoolType.AxS) {
 			this.validationForm.addControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-beatmap-${newModBracketMap.index}-modifier`, new FormControl('', Validators.required));
 		}
+
+		if (this.mappool.type == MappoolType.CTMTournament) {
+			this.validationForm.addControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-beatmap-${newModBracketMap.index}-damage-amount`, new FormControl('', Validators.required));
+		}
 	}
 
 	/**
@@ -194,6 +204,10 @@ export class ModBracketComponent implements OnInit {
 
 			if (this.mappool.type == MappoolType.AxS) {
 				this.validationForm.addControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-beatmap-${newModBracketMap.index}-modifier`, new FormControl('', Validators.required));
+			}
+
+			if (this.mappool.type == MappoolType.CTMTournament) {
+				this.validationForm.addControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-beatmap-${newModBracketMap.index}-damage-amount`, new FormControl('', Validators.required));
 			}
 		});
 	}
@@ -250,6 +264,10 @@ export class ModBracketComponent implements OnInit {
 
 		if (this.mappool.type == MappoolType.AxS) {
 			this.validationForm.removeControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-beatmap-${beatmap.index}-modifier`);
+		}
+
+		if (this.mappool.type == MappoolType.CTMTournament) {
+			this.validationForm.removeControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-beatmap-${beatmap.index}-damage-amount`);
 		}
 	}
 

--- a/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
@@ -113,6 +113,12 @@ export class TournamentEditComponent implements OnInit {
 									this.validationForm.addControl(`mappool-${mappool.index}-mod-bracket-${modBracket.index}-beatmap-${beatmap.index}-modifier`, new FormControl(beatmap.modifier, Validators.required));
 								}
 							}
+
+							if (mappool.type == MappoolType.CTMTournament) {
+								for (const beatmap of modBracket.beatmaps) {
+									this.validationForm.addControl(`mappool-${mappool.index}-mod-bracket-${modBracket.index}-beatmap-${beatmap.index}-damage-amount`, new FormControl(beatmap.damageAmount, Validators.required));
+								}
+							}
 						}
 
 						for (const category of mappool.modCategories) {

--- a/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
@@ -3,6 +3,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Params } from '@angular/router';
 import { Mods } from 'app/models/osu-models/osu';
 import { Calculate } from 'app/models/score-calculation/calculate';
+import { CTMCalculation } from 'app/models/score-calculation/calculation-types/ctm-calculation';
 import { ToastType } from 'app/models/toast';
 import { MappoolType } from 'app/models/wytournament/mappool/wy-mappool';
 import { WyTournament } from 'app/models/wytournament/wy-tournament';
@@ -70,6 +71,10 @@ export class TournamentEditComponent implements OnInit {
 					for (const stage of tournament.stages) {
 						this.validationForm.addControl(`tournament-stage-name-${stage.index}`, new FormControl(stage.name, Validators.required));
 						this.validationForm.addControl(`tournament-stage-best-of-${stage.index}`, new FormControl(Number(stage.bestOf), Validators.required));
+
+						if (tournament.scoreInterface instanceof CTMCalculation) {
+							this.validationForm.addControl(`tournament-stage-hitpoints-${stage.index}`, new FormControl(stage.hitpoints, Validators.required));
+						}
 					}
 
 					for (const webhook of tournament.webhooks) {

--- a/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
@@ -95,6 +95,12 @@ export class TournamentPublishedEditComponent implements OnInit {
 									this.validationForm.addControl(`mappool-${mappool.index}-mod-bracket-${modBracket.index}-beatmap-${beatmap.index}-modifier`, new FormControl(beatmap.modifier, Validators.required));
 								}
 							}
+
+							if (mappool.type == MappoolType.CTMTournament) {
+								for (const beatmap of modBracket.beatmaps) {
+									this.validationForm.addControl(`mappool-${mappool.index}-mod-bracket-${modBracket.index}-beatmap-${beatmap.index}-damage-amount`, new FormControl(beatmap.damageAmount, Validators.required));
+								}
+							}
 						}
 					}
 

--- a/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Params } from '@angular/router';
 import { Mods } from 'app/models/osu-models/osu';
 import { Calculate } from 'app/models/score-calculation/calculate';
+import { CTMCalculation } from 'app/models/score-calculation/calculation-types/ctm-calculation';
 import { ToastType } from 'app/models/toast';
 import { MappoolType } from 'app/models/wytournament/mappool/wy-mappool';
 import { WyTournament } from 'app/models/wytournament/wy-tournament';
@@ -68,6 +69,10 @@ export class TournamentPublishedEditComponent implements OnInit {
 				for (const stage of tournament.stages) {
 					this.validationForm.addControl(`tournament-stage-name-${stage.index}`, new FormControl(stage.name, Validators.required));
 					this.validationForm.addControl(`tournament-stage-best-of-${stage.index}`, new FormControl(Number(stage.bestOf), Validators.required));
+
+					if (tournament.scoreInterface instanceof CTMCalculation) {
+						this.validationForm.addControl(`tournament-stage-hitpoints-${stage.index}`, new FormControl(stage.hitpoints, Validators.required));
+					}
 				}
 
 				for (const mappool of tournament.mappools) {

--- a/src/app/modules/tournament-management/components/tournament/tournament-beatmap-result/tournament-beatmap-result.component.html
+++ b/src/app/modules/tournament-management/components/tournament/tournament-beatmap-result/tournament-beatmap-result.component.html
@@ -21,6 +21,14 @@
 		<li><code>{{ '{' }}{{ '{' }}matchWinner{{ '}' }}{{ '}' }}</code>: the team name of the winner of the match</li>
 	</ul>
 
+	<b>The following variables are only used for the Catch The Magic tournament</b>
+
+	<ul>
+		<li><code>{{ '{' }}{{ '{' }}teamOneHitpoints{{ '}' }}{{ '}' }}</code>: the hitpoints that team one has left</li>
+		<li><code>{{ '{' }}{{ '{' }}teamTwoHitpoints{{ '}' }}{{ '}' }}</code>: the hitpoints that team two has left</li>
+		<li><code>{{ '{' }}{{ '{' }}damageDealt{{ '}' }}{{ '}' }}</code>: the damage that was dealt by the beatmap</li>
+	</ul>
+
 	<p>Example message: <code>Score: {{ '{' }}{{ '{' }}matchTeamOneScore{{ '}' }}{{ '}' }} | {{ '{' }}{{ '{' }}matchTeamTwoScore{{ '}' }}{{ '}' }}</code></p>
 
 	<hr />

--- a/src/app/modules/tournament-management/components/tournament/tournament-general/tournament-general.component.ts
+++ b/src/app/modules/tournament-management/components/tournament/tournament-general/tournament-general.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSelectChange } from '@angular/material/select';
 import { Calculate } from 'app/models/score-calculation/calculate';
+import { CTMCalculation } from 'app/models/score-calculation/calculation-types/ctm-calculation';
 import { TournamentFormat, WyTournament } from 'app/models/wytournament/wy-tournament';
 
 @Component({
@@ -31,6 +32,17 @@ export class TournamentGeneralComponent implements OnInit {
 
 		this.validationForm.get('tournament-team-size').setValue(selectedScoreInterface.getTeamSize());
 		this.validationForm.get('tournament-format').setValue((selectedScoreInterface.isSoloTournament() != null && selectedScoreInterface.isSoloTournament() == true ? TournamentFormat.Solo : TournamentFormat.Teams));
+
+		if (this.tournament.scoreInterface instanceof CTMCalculation && !(selectedScoreInterface instanceof CTMCalculation)) {
+			for (const stage of this.tournament.stages) {
+				this.validationForm.removeControl(`tournament-stage-hitpoints-${stage.index}`);
+			}
+		}
+		else if (selectedScoreInterface instanceof CTMCalculation) {
+			for (const stage of this.tournament.stages) {
+				this.validationForm.addControl(`tournament-stage-hitpoints-${stage.index}`, new FormControl('', Validators.required));
+			}
+		}
 
 		this.tournament.scoreInterface = selectedScoreInterface;
 		this.tournament.scoreInterfaceIdentifier = selectedScoreInterface.getIdentifier();

--- a/src/app/modules/tournament-management/components/tournament/tournament-stages/tournament-stages.component.html
+++ b/src/app/modules/tournament-management/components/tournament/tournament-stages/tournament-stages.component.html
@@ -12,7 +12,7 @@
 		<div class="row">
 			<div class="col">
 				<div class="all-stages">
-					<div class="stage" *ngFor="let stage of tournament.stages">
+					<div class="stage" *ngFor="let stage of tournament.stages" [ngStyle]="{'grid-template-columns': tournament.scoreInterfaceIdentifier == CTM_SCORE_IDENTIFIER ? '2fr 1fr 1fr 50px' : '2fr 1fr 50px'}">
 						<div class="name">
 							<mat-form-field class="full-width">
 								<mat-label>Stage name</mat-label>
@@ -20,6 +20,18 @@
 								<input matInput [formControlName]="'tournament-stage-name-' + stage.index" (change)="changeStageName(stage, $event)" />
 
 								<mat-error *ngIf="validationForm.get('tournament-stage-name-' + stage.index) != null && validationForm.get('tournament-stage-name-' + stage.index).errors && (validationForm.get('tournament-stage-name-' + stage.index).touched || validationForm.get('tournament-stage-name-' + stage.index).dirty)">
+									This field is required
+								</mat-error>
+							</mat-form-field>
+						</div>
+
+						<div class="health-start" *ngIf="tournament.scoreInterfaceIdentifier == CTM_SCORE_IDENTIFIER">
+							<mat-form-field class="full-width">
+								<mat-label>Hitpoints start amount</mat-label>
+
+								<input matInput [formControlName]="'tournament-stage-hitpoints-' + stage.index" (change)="changeStageHitpoints(stage, $event)" />
+
+								<mat-error *ngIf="validationForm.get('tournament-stage-hitpoints-' + stage.index) != null && validationForm.get('tournament-stage-hitpoints-' + stage.index).errors && (validationForm.get('tournament-stage-hitpoints-' + stage.index).touched || validationForm.get('tournament-stage-hitpoints-' + stage.index).dirty)">
 									This field is required
 								</mat-error>
 							</mat-form-field>

--- a/src/app/modules/tournament-management/components/tournament/tournament-stages/tournament-stages.component.scss
+++ b/src/app/modules/tournament-management/components/tournament/tournament-stages/tournament-stages.component.scss
@@ -6,20 +6,9 @@
 	padding-bottom: 8px;
 
 	.stage {
-		display: flex;
-		flex: 1;
-
-		.name {
-			flex: 1 1 50%;
-
-			margin-right: 8px;
-		}
-
-		.bestof {
-			flex: 1 1 50%;
-
-			margin-right: 8px;
-		}
+		display: grid;
+		grid-auto-flow: column;
+		gap: 8px;
 
 		.actions {
 			display: flex;

--- a/src/app/modules/tournament-management/components/tournament/tournament-stages/tournament-stages.component.ts
+++ b/src/app/modules/tournament-management/components/tournament/tournament-stages/tournament-stages.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { Calculate } from 'app/models/score-calculation/calculate';
+import { CTMCalculation } from 'app/models/score-calculation/calculation-types/ctm-calculation';
 import { WyStage } from 'app/models/wytournament/wy-stage';
 import { WyTournament } from 'app/models/wytournament/wy-tournament';
 
@@ -12,7 +14,19 @@ export class TournamentStagesComponent implements OnInit {
 	@Input() tournament: WyTournament;
 	@Input() validationForm: FormGroup;
 
-	constructor() { }
+	readonly CTM_SCORE_IDENTIFIER: string;
+
+	constructor() {
+		const calculate = new Calculate();
+
+		for (const scoreInterface of calculate.getAllScoreInterfaces()) {
+			if (scoreInterface instanceof CTMCalculation) {
+				this.CTM_SCORE_IDENTIFIER = scoreInterface.getIdentifier();
+				break;
+			}
+		}
+	}
+
 	ngOnInit(): void { }
 
 	/**
@@ -28,6 +42,10 @@ export class TournamentStagesComponent implements OnInit {
 
 		this.validationForm.addControl(`tournament-stage-name-${newStage.index}`, new FormControl('', Validators.required));
 		this.validationForm.addControl(`tournament-stage-best-of-${newStage.index}`, new FormControl('', Validators.required));
+
+		if (this.tournament.scoreInterface instanceof CTMCalculation) {
+			this.validationForm.addControl(`tournament-stage-hitpoints-${newStage.index}`, new FormControl('', Validators.required));
+		}
 	}
 
 	/**
@@ -38,6 +56,16 @@ export class TournamentStagesComponent implements OnInit {
 	 */
 	changeStageName(stage: WyStage, event: any) {
 		stage.name = event.target.value;
+	}
+
+	/**
+	 * Change the starting amount of hitpoints of the stage
+	 *
+	 * @param stage the stage to change the starting amount of hitpoints of
+	 * @param event the changed value
+	 */
+	changeStageHitpoints(stage: WyStage, event: any) {
+		stage.hitpoints = event.target.value;
 	}
 
 	/**
@@ -58,6 +86,10 @@ export class TournamentStagesComponent implements OnInit {
 	removeStage(stage: WyStage) {
 		this.validationForm.removeControl(`tournament-stage-name-${stage.index}`);
 		this.validationForm.removeControl(`tournament-stage-best-of-${stage.index}`);
+
+		if (this.tournament.scoreInterface instanceof CTMCalculation) {
+			this.validationForm.removeControl(`tournament-stage-hitpoints-${stage.index}`);
+		}
 
 		this.tournament.stages.splice(this.tournament.stages.indexOf(stage), 1);
 	}

--- a/src/app/services/wy-multiplayer-lobbies.service.ts
+++ b/src/app/services/wy-multiplayer-lobbies.service.ts
@@ -26,6 +26,8 @@ import { StoreService } from './store.service';
 import { ToastService } from './toast.service';
 import { TournamentService } from './tournament.service';
 import { WebhookService } from './webhook.service';
+import { CTMCalculation } from 'app/models/score-calculation/calculation-types/ctm-calculation';
+import { WyModBracketMap } from 'app/models/wytournament/mappool/wy-mod-bracket-map';
 
 @Injectable({
 	providedIn: 'root'
@@ -167,6 +169,9 @@ export class WyMultiplayerLobbiesService {
 			multiplayerLobby.teamOneScore = 0;
 			multiplayerLobby.teamTwoScore = 0;
 
+			multiplayerLobby.teamOneHealth = 50;
+			multiplayerLobby.teamTwoHealth = 50;
+
 			for (const currentGame of multiplayerMatch.games) {
 				const multiplayerData = new MultiplayerData({
 					game_id: currentGame.game_id,
@@ -200,6 +205,8 @@ export class WyMultiplayerLobbiesService {
 					});
 				}
 
+				let foundModBracketBeatmap: WyModBracketMap;
+
 				for (const currentScore of currentGame.scores) {
 					const cachedUser: CacheUser = this.cacheService.getCachedUser(currentScore.user_id);
 
@@ -231,6 +238,7 @@ export class WyMultiplayerLobbiesService {
 							for (const map of modBracket.beatmaps) {
 								if (map.beatmapId == currentGame.beatmap_id) {
 									beatmapFound = true;
+									foundModBracketBeatmap = map;
 									break;
 								}
 							}
@@ -296,11 +304,19 @@ export class WyMultiplayerLobbiesService {
 				if (multiplayerData.team_one_score > multiplayerData.team_two_score) {
 					if (multiplayerLobby.gamesCountTowardsScore.hasOwnProperty(multiplayerData.game_id) && multiplayerLobby.gamesCountTowardsScore[multiplayerData.game_id] == true) {
 						multiplayerLobby.teamOneScore++;
+
+						if (scoreInterface instanceof CTMCalculation) {
+							multiplayerLobby.teamTwoHealth -= foundModBracketBeatmap.damageAmount;
+						}
 					}
 				}
 				else {
 					if (multiplayerLobby.gamesCountTowardsScore.hasOwnProperty(multiplayerData.game_id) && multiplayerLobby.gamesCountTowardsScore[multiplayerData.game_id] == true) {
 						multiplayerLobby.teamTwoScore++;
+
+						if (scoreInterface instanceof CTMCalculation) {
+							multiplayerLobby.teamOneHealth -= foundModBracketBeatmap.damageAmount;
+						}
 					}
 				}
 

--- a/src/app/services/wy-multiplayer-lobbies.service.ts
+++ b/src/app/services/wy-multiplayer-lobbies.service.ts
@@ -298,6 +298,10 @@ export class WyMultiplayerLobbiesService {
 					}
 				}
 
+				if (scoreInterface instanceof CTMCalculation) {
+					scoreInterface.setBeatmap(foundModBracketBeatmap);
+				}
+
 				multiplayerData.team_one_score = scoreInterface.calculateTeamOneScore();
 				multiplayerData.team_two_score = scoreInterface.calculateTeamTwoScore();
 

--- a/src/app/services/wy-multiplayer-lobbies.service.ts
+++ b/src/app/services/wy-multiplayer-lobbies.service.ts
@@ -169,8 +169,8 @@ export class WyMultiplayerLobbiesService {
 			multiplayerLobby.teamOneScore = 0;
 			multiplayerLobby.teamTwoScore = 0;
 
-			multiplayerLobby.teamOneHealth = 50;
-			multiplayerLobby.teamTwoHealth = 50;
+			multiplayerLobby.teamOneHealth = Number(multiplayerLobby.selectedStage.hitpoints);
+			multiplayerLobby.teamTwoHealth = Number(multiplayerLobby.selectedStage.hitpoints);
 
 			for (const currentGame of multiplayerMatch.games) {
 				const multiplayerData = new MultiplayerData({


### PR DESCRIPTION
Catch The Magic 4 referee helper

- Implement Hitpoints system instead of traditional score system
    - The base hitpoints a match starts out with can be set per stage
    - Beating a team now removes hitpoints from the opposing team
    - The damage that gets dealt can be set per beatmap
- Give additional score to a team based on selected mods, this is only enabled when a beatmap is supposed to deal 6 or 8 damage
    - The additional score is capped at 150k
    - When Easy is enabled, the additional score is set to 525k and will ignore any other bonus modifiers
    - HR gives a bonus score of 50k
    - DT gives a bonus score of 75k
    - FL gives a bonus score of 100k
    - SD gives a bonus score of 150k
    - HD does **not** give any extra score
- Added 3 new variables for beatmap result messages to show the hitpoints and damage dealt