### PR TITLE
Ignore navigating through irc message history when holding down modifier keys

### DIFF
--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -187,6 +187,12 @@ export class IrcComponent implements OnInit {
 	 */
 	@HostListener('document:keyup', ['$event'])
 	handleKeyboardEvent(event: KeyboardEvent) {
+		const modifiers = ['Shift', 'Alt', 'Control'];
+
+		if (modifiers.some(modifier => event.getModifierState(modifier))) {
+			return;
+		}
+
 		if (event.key == 'ArrowUp') {
 			this.navigateMessageHistory(-1);
 		}


### PR DESCRIPTION
When holding `CTRL`, `SHIFT` or `ALT` when pressing `Arrow Up` or `Arrow Down` it will no longer navigate through the message history