### PR TITLE
Match summary webhook

### DIFF
--- a/src/app/models/wytournament/wy-tournament.ts
+++ b/src/app/models/wytournament/wy-tournament.ts
@@ -6,6 +6,8 @@ import { WyWebhook } from './wy-webhook';
 import { WyTeam } from './wy-team';
 import { WyStage } from './wy-stage';
 import { WyBeatmapResultMessage } from './wy-beatmap-result-message';
+import { WyModBracket } from './mappool/wy-mod-bracket';
+import { WyModBracketMap } from './mappool/wy-mod-bracket-map';
 
 export enum TournamentFormat {
 	Solo = 'solo',
@@ -257,6 +259,30 @@ export class WyTournament {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get the beatmap for the match summary
+	 *
+	 * @param beatmapId the id of the beatmap to get
+	 */
+	getBeatmapForMatchSummary(beatmapId: number): string {
+		let foundModBracket: WyModBracket = null;
+		let foundBeatmap: WyModBracketMap = null;
+
+		for (const mappool of this.mappools) {
+			for (const modBracket of mappool.modBrackets) {
+				for (const beatmap of modBracket.beatmaps) {
+					if (beatmap.beatmapId == beatmapId) {
+						foundModBracket = modBracket;
+						foundBeatmap = beatmap;
+						break;
+					}
+				}
+			}
+		}
+
+		return `**${foundModBracket.acronym}${foundBeatmap.index + 1}**: [${foundBeatmap.beatmapName}](${foundBeatmap.beatmapUrl})`;
 	}
 
 	/**

--- a/src/app/models/wytournament/wy-tournament.ts
+++ b/src/app/models/wytournament/wy-tournament.ts
@@ -282,7 +282,7 @@ export class WyTournament {
 			}
 		}
 
-		return `**${foundModBracket.acronym}${foundBeatmap.index + 1}**: [${foundBeatmap.beatmapName}](${foundBeatmap.beatmapUrl})`;
+		return `[${foundModBracket.acronym}${foundBeatmap.index + 1}](${foundBeatmap.beatmapUrl})`;
 	}
 
 	/**

--- a/src/app/models/wytournament/wy-webhook.ts
+++ b/src/app/models/wytournament/wy-webhook.ts
@@ -21,6 +21,11 @@ export class WyWebhook {
 	bans: boolean;
 
 	/**
+	 * Whenever a button gets pressed by the referee, an embed with the match summary will be sent to the channel
+	 */
+	matchSummary: boolean;
+
+	/**
 	 * Whenever a beatmap finishes, an embed will be sent to the channel
 	 */
 	matchResult: boolean;
@@ -43,6 +48,7 @@ export class WyWebhook {
 			matchCreation: webhook.matchCreation,
 			picks: webhook.picks,
 			bans: webhook.bans,
+			matchSummary: webhook.matchSummary,
 			matchResult: webhook.matchResult,
 			finalResult: webhook.finalResult
 		});

--- a/src/app/models/wytournament/wy-webhook.ts
+++ b/src/app/models/wytournament/wy-webhook.ts
@@ -45,12 +45,12 @@ export class WyWebhook {
 			index: webhook.index,
 			name: webhook.name,
 			url: webhook.url,
-			matchCreation: webhook.matchCreation,
-			picks: webhook.picks,
-			bans: webhook.bans,
-			matchSummary: webhook.matchSummary,
-			matchResult: webhook.matchResult,
-			finalResult: webhook.finalResult
+			matchCreation: webhook.matchCreation == null ? false : webhook.matchCreation,
+			picks: webhook.picks == null ? false : webhook.picks,
+			bans: webhook.bans == null ? false : webhook.bans,
+			matchSummary: webhook.matchSummary == null ? false : webhook.matchSummary,
+			matchResult: webhook.matchResult == null ? false : webhook.matchResult,
+			finalResult: webhook.finalResult == null ? false : webhook.finalResult
 		});
 	}
 }

--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -272,6 +272,10 @@
 					<mat-icon>chat</mat-icon>
 				</div>
 
+				<div class="header-button" matTooltip="Send match summary" (click)="sendMatchSummary()" *ngIf="selectedLobby && (selectedLobby.tournament != null || selectedLobby.tournament != undefined)">
+					<mat-icon>view_list</mat-icon>
+				</div>
+
 				<div class="header-button" matTooltip="Send final result to Discord webhook" (click)="sendFinalResult()" *ngIf="selectedLobby && (selectedLobby.tournament != null || selectedLobby.tournament != undefined)">
 					<mat-icon>send</mat-icon>
 				</div>

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -794,6 +794,14 @@ export class IrcComponent implements OnInit {
 	}
 
 	/**
+	 * Send the match summary to the given Discord webhooks
+	 */
+	sendMatchSummary() {
+		const selectedMultiplayerLobby = this.multiplayerLobbies.getMultiplayerLobbyByIrc(this.selectedChannel.name);
+		this.webhookService.sendMatchSummary(selectedMultiplayerLobby, this.ircService.authenticatedUser);
+	}
+
+	/**
 	 * Send the final result to discord
 	 */
 	sendFinalResult() {

--- a/src/app/modules/tournament-management/components/tournament-create/tournament-create.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-create/tournament-create.component.ts
@@ -95,6 +95,7 @@ export class TournamentCreateComponent implements OnInit {
 				webhook.matchCreation = this.validationForm.get(`webhook-${webhook.index}-match-creation`).value;
 				webhook.picks = this.validationForm.get(`webhook-${webhook.index}-picks`).value;
 				webhook.bans = this.validationForm.get(`webhook-${webhook.index}-bans`).value;
+				webhook.matchSummary = this.validationForm.get(`webhook-${webhook.index}-match-summary`).value;
 				webhook.matchResult = this.validationForm.get(`webhook-${webhook.index}-match-result`).value;
 				webhook.finalResult = this.validationForm.get(`webhook-${webhook.index}-final-result`).value;
 			}

--- a/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
@@ -175,6 +175,7 @@ export class TournamentEditComponent implements OnInit {
 				webhook.matchCreation = this.validationForm.get(`webhook-${webhook.index}-match-creation`).value;
 				webhook.picks = this.validationForm.get(`webhook-${webhook.index}-picks`).value;
 				webhook.bans = this.validationForm.get(`webhook-${webhook.index}-bans`).value;
+				webhook.matchSummary = this.validationForm.get(`webhook-${webhook.index}-match-summary`).value;
 				webhook.matchResult = this.validationForm.get(`webhook-${webhook.index}-match-result`).value;
 				webhook.finalResult = this.validationForm.get(`webhook-${webhook.index}-final-result`).value;
 			}

--- a/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-edit/tournament-edit.component.ts
@@ -84,6 +84,7 @@ export class TournamentEditComponent implements OnInit {
 						this.validationForm.addControl(`webhook-${webhook.index}-match-creation`, new FormControl(webhook.matchCreation, Validators.required));
 						this.validationForm.addControl(`webhook-${webhook.index}-picks`, new FormControl(webhook.picks, Validators.required));
 						this.validationForm.addControl(`webhook-${webhook.index}-bans`, new FormControl(webhook.bans, Validators.required));
+						this.validationForm.addControl(`webhook-${webhook.index}-match-summary`, new FormControl(webhook.matchSummary, Validators.required));
 						this.validationForm.addControl(`webhook-${webhook.index}-match-result`, new FormControl(webhook.matchResult, Validators.required));
 						this.validationForm.addControl(`webhook-${webhook.index}-final-result`, new FormControl(webhook.finalResult, Validators.required));
 					}

--- a/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
@@ -121,6 +121,7 @@ export class TournamentPublishedEditComponent implements OnInit {
 					this.validationForm.addControl(`webhook-${webhook.index}-match-creation`, new FormControl(webhook.matchCreation, Validators.required));
 					this.validationForm.addControl(`webhook-${webhook.index}-picks`, new FormControl(webhook.picks, Validators.required));
 					this.validationForm.addControl(`webhook-${webhook.index}-bans`, new FormControl(webhook.bans, Validators.required));
+					this.validationForm.addControl(`webhook-${webhook.index}-match-summary`, new FormControl(webhook.matchSummary, Validators.required));
 					this.validationForm.addControl(`webhook-${webhook.index}-match-result`, new FormControl(webhook.matchResult, Validators.required));
 					this.validationForm.addControl(`webhook-${webhook.index}-final-result`, new FormControl(webhook.finalResult, Validators.required));
 				}

--- a/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-published-edit/tournament-published-edit.component.ts
@@ -171,6 +171,7 @@ export class TournamentPublishedEditComponent implements OnInit {
 				webhook.matchCreation = this.validationForm.get(`webhook-${webhook.index}-match-creation`).value;
 				webhook.picks = this.validationForm.get(`webhook-${webhook.index}-picks`).value;
 				webhook.bans = this.validationForm.get(`webhook-${webhook.index}-bans`).value;
+				webhook.matchSummary = this.validationForm.get(`webhook-${webhook.index}-match-summary`).value;
 				webhook.matchResult = this.validationForm.get(`webhook-${webhook.index}-match-result`).value;
 				webhook.finalResult = this.validationForm.get(`webhook-${webhook.index}-final-result`).value;
 			}

--- a/src/app/modules/tournament-management/components/tournament/tournament-webhook/tournament-webhook.component.html
+++ b/src/app/modules/tournament-management/components/tournament/tournament-webhook/tournament-webhook.component.html
@@ -21,6 +21,53 @@
 
 	<hr />
 
+	<h3>Webhook options explanation</h3>
+	<ul>
+		<li>
+			Match creation
+			<ul>
+				<li>Whenever a match gets created, an embed message will be sent to the channel with information of the match</li>
+			</ul>
+		</li>
+
+		<li>
+			Picks
+			<ul>
+				<li>Whenever a beatmap gets picked, an embed message will be sent to the channel with which player/team has picked which beatmap</li>
+			</ul>
+		</li>
+
+		<li>
+			Bans
+			<ul>
+				<li>Whenever a beatmap gets banned, an embed message will be sent to the channel with which player/team has banned which beatmap</li>
+			</ul>
+		</li>
+
+		<li>
+			Match summary
+			<ul>
+				<li>Whenever a referee presses the button for the match summary, an embed message will be sent to the channel with the full match summary such as picks and bans</li>
+			</ul>
+		</li>
+
+		<li>
+			Match result
+			<ul>
+				<li>Whenever the players/teams have finished the beatmap, an embed message will be sent to the channel showing which team has won the pick as well as showing the current match score</li>
+			</ul>
+		</li>
+
+		<li>
+			Final creation
+			<ul>
+				<li>Whenever a referee clicks on the dialog to send the final result, an embed message will be sent to the channel showing the final score, multiplayer link, first pick and bans of the match</li>
+			</ul>
+		</li>
+	</ul>
+
+	<hr />
+
 	<button mat-raised-button color="primary" (click)="createWebhook()"><mat-icon>add</mat-icon> add new webhook</button>
 
 	<app-alert alertType="info" *ngIf="tournament.webhooks.length <= 0">
@@ -88,6 +135,14 @@
 					</div>
 
 					<mat-slide-toggle [formControlName]="'webhook-' + webhook.index + '-bans'"></mat-slide-toggle>
+				</div>
+
+				<div class="option">
+					<div class="description">
+						Match summary
+					</div>
+
+					<mat-slide-toggle [formControlName]="'webhook-' + webhook.index + '-match-summary'"></mat-slide-toggle>
 				</div>
 
 				<div class="option">

--- a/src/app/modules/tournament-management/components/tournament/tournament-webhook/tournament-webhook.component.ts
+++ b/src/app/modules/tournament-management/components/tournament/tournament-webhook/tournament-webhook.component.ts
@@ -23,6 +23,7 @@ export class TournamentWebhookComponent implements OnInit {
 		this.validationForm.addControl(`webhook-${this.tournament.webhookIndex}-match-creation`, new FormControl(false, Validators.required));
 		this.validationForm.addControl(`webhook-${this.tournament.webhookIndex}-picks`, new FormControl(false, Validators.required));
 		this.validationForm.addControl(`webhook-${this.tournament.webhookIndex}-bans`, new FormControl(true, Validators.required));
+		this.validationForm.addControl(`webhook-${this.tournament.webhookIndex}-match-summary`, new FormControl(false, Validators.required));
 		this.validationForm.addControl(`webhook-${this.tournament.webhookIndex}-match-result`, new FormControl(true, Validators.required));
 		this.validationForm.addControl(`webhook-${this.tournament.webhookIndex}-final-result`, new FormControl(true, Validators.required));
 
@@ -40,6 +41,7 @@ export class TournamentWebhookComponent implements OnInit {
 		this.validationForm.removeControl(`webhook-${this.tournament.webhookIndex}-match-creation`);
 		this.validationForm.removeControl(`webhook-${this.tournament.webhookIndex}-picks`);
 		this.validationForm.removeControl(`webhook-${this.tournament.webhookIndex}-bans`);
+		this.validationForm.removeControl(`webhook-${this.tournament.webhookIndex}-match-summary`);
 		this.validationForm.removeControl(`webhook-${this.tournament.webhookIndex}-match-result`);
 		this.validationForm.removeControl(`webhook-${this.tournament.webhookIndex}-final-result`);
 

--- a/src/app/services/webhook.service.ts
+++ b/src/app/services/webhook.service.ts
@@ -344,20 +344,20 @@ export class WebhookService {
 			if (firstPickTeam === 1) {
 				if (i < teamOneLength) {
 					const teamOnePick = selectedLobby.teamOnePicks[i];
-					picks.push(`**${selectedLobby.teamOneName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamOnePick)}`);
+					picks.push(`${selectedLobby.tournament.getBeatmapForMatchSummary(teamOnePick)} was picked by **${selectedLobby.teamOneName}**`);
 				}
 				if (i < teamTwoLength) {
 					const teamTwoPick = selectedLobby.teamTwoPicks[i];
-					picks.push(`**${selectedLobby.teamTwoName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamTwoPick)}`);
+					picks.push(`${selectedLobby.tournament.getBeatmapForMatchSummary(teamTwoPick)} was picked by **${selectedLobby.teamTwoName}**`);
 				}
 			} else if (firstPickTeam === 2) {
 				if (i < teamTwoLength) {
 					const teamTwoPick = selectedLobby.teamTwoPicks[i];
-					picks.push(`**${selectedLobby.teamTwoName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamTwoPick)}`);
+					picks.push(`${selectedLobby.tournament.getBeatmapForMatchSummary(teamTwoPick)} was picked by **${selectedLobby.teamTwoName}**`);
 				}
 				if (i < teamOneLength) {
 					const teamOnePick = selectedLobby.teamOnePicks[i];
-					picks.push(`**${selectedLobby.teamOneName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamOnePick)}`);
+					picks.push(`${selectedLobby.tournament.getBeatmapForMatchSummary(teamOnePick)} was picked by **${selectedLobby.teamOneName}**`);
 				}
 			}
 		}

--- a/src/app/services/webhook.service.ts
+++ b/src/app/services/webhook.service.ts
@@ -312,6 +312,98 @@ export class WebhookService {
 	}
 
 	/**
+	 * Send a summary of the match through a discord webhook
+	 *
+	 * @param selectedLobby the lobby to get the data from
+	 * @param referee the referee that is running the lobby
+	 */
+	sendMatchSummary(selectedLobby: Lobby, referee: string) {
+		if (!this.doSendWebhooks(selectedLobby)) {
+			return;
+		}
+
+		const teamOneBans = [];
+		const teamTwoBans = [];
+
+		for (const ban of selectedLobby.teamOneBans) {
+			teamOneBans.push(selectedLobby.tournament.getBeatmapForMatchSummary(ban));
+		}
+
+		for (const ban of selectedLobby.teamTwoBans) {
+			teamTwoBans.push(selectedLobby.tournament.getBeatmapForMatchSummary(ban));
+		}
+
+		const firstPickTeam = selectedLobby.firstPick == selectedLobby.teamOneName ? 1 : 2;
+		const teamOneLength = selectedLobby.teamOnePicks.length;
+		const teamTwoLength = selectedLobby.teamTwoPicks.length;
+		const maxLength = Math.max(teamOneLength, teamTwoLength);
+
+		const picks: string[] = [];
+
+		for (let i = 0; i < maxLength; i++) {
+			if (firstPickTeam === 1) {
+				if (i < teamOneLength) {
+					const teamOnePick = selectedLobby.teamOnePicks[i];
+					picks.push(`**${selectedLobby.teamOneName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamOnePick)}`);
+				}
+				if (i < teamTwoLength) {
+					const teamTwoPick = selectedLobby.teamTwoPicks[i];
+					picks.push(`**${selectedLobby.teamTwoName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamTwoPick)}`);
+				}
+			} else if (firstPickTeam === 2) {
+				if (i < teamTwoLength) {
+					const teamTwoPick = selectedLobby.teamTwoPicks[i];
+					picks.push(`**${selectedLobby.teamTwoName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamTwoPick)}`);
+				}
+				if (i < teamOneLength) {
+					const teamOnePick = selectedLobby.teamOnePicks[i];
+					picks.push(`**${selectedLobby.teamOneName}** picked ${selectedLobby.tournament.getBeatmapForMatchSummary(teamOnePick)}`);
+				}
+			}
+		}
+
+		const body = {
+			embeds: [
+				{
+					title: `Match summary - ${selectedLobby.teamOneName} vs ${selectedLobby.teamTwoName}`,
+					url: selectedLobby.multiplayerLink,
+					color: 15258703,
+					footer: {
+						text: `Match referee was ${referee}`
+					},
+					fields: [
+					]
+				}
+			]
+		};
+
+		body.embeds[0].fields.push(
+			{
+				name: `${selectedLobby.teamOneName} bans`,
+				value: teamOneBans.join('\n'),
+				inline: true
+			},
+			{
+				name: `${selectedLobby.teamTwoName} bans`,
+				value: teamTwoBans.join('\n'),
+				inline: true
+			});
+
+		body.embeds[0].fields.push(
+			{
+				name: 'Match picks',
+				value: picks.join('\n')
+			});
+
+		for (const webhook of selectedLobby.tournament.webhooks) {
+			if (webhook.matchSummary == true) {
+				console.log('found webhook, sending');
+				this.http.post(webhook.url, body, { headers: new HttpHeaders({ 'Content-type': 'application/json' }) }).subscribe();
+			}
+		}
+	}
+
+	/**
 	 * Send the result of the last played beatmap to a discord webhook
 	 *
 	 * @param multiplayerLobby the lobby to get the data from


### PR DESCRIPTION
Implement a button to send the match summary to a Discord webhook

- Shows the title and the multiplayer link of the current match
- Shows the bans of each teams
- Shows the picks of each teams and sort it in the correct pick order