### PR TITLE
Fix acronym check in chat for empty mod brackets

### DIFF
--- a/src/app/models/wytournament/mappool/wy-mappool.ts
+++ b/src/app/models/wytournament/mappool/wy-mappool.ts
@@ -220,7 +220,7 @@ export class WyMappool {
 		const regexOptions: string[] = [];
 
 		for (const modBracket of this.modBrackets) {
-			if (modBracket.acronym) {
+			if (modBracket.acronym && modBracket.beatmaps.length > 0) {
 				if (fullRegex == true) {
 					regexOptions.push(`(${modBracket.acronym}\\s?[1-${modBracket.beatmaps.length}])`);
 				}


### PR DESCRIPTION
When a mod bracket exists in a mappool but no maps have been added, it was causing issues making you no longer able to type in chat

Added a check to see whether there are maps in the specific mod bracket, if not the mod bracket can be ignored