### PR TITLE
Add option to toggle split Bancho messages

### DIFF
--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -155,7 +155,7 @@
 			</div>
 
 			<!-- Banchobot messages -->
-			<virtual-scroller #banchoBotVirtualScroller *ngIf="selectedChannel != null && selectedChannel.name.startsWith('#mp_')" [ngStyle]="{'height': dividerHeightPercentage + '%'}" class="messages banchobot" [items]="banchoBotChats" [stripedTable]="true" (vsUpdate)="banchoBotViewPortItems = $event">
+			<virtual-scroller #banchoBotVirtualScroller *ngIf="selectedChannel != null && selectedChannel.name.startsWith('#mp_') && splitBanchoMessages == true" [ngStyle]="{'height': dividerHeightPercentage + '%'}" class="messages banchobot" [items]="banchoBotChats" [stripedTable]="true" (vsUpdate)="banchoBotViewPortItems = $event">
 				<app-alert alertType="warn" *ngIf="banchoBotChats.length == 0 && selectedChannel != undefined">There are no messages yet.</app-alert>
 				<app-alert alertType="warn" *ngIf="banchoBotChats.length == 0 && selectedChannel == undefined">There is no selected channel.</app-alert>
 
@@ -190,7 +190,7 @@
 				</div>
 			</virtual-scroller>
 
-			<div class="messages-divider" *ngIf="selectedChannel != null && selectedChannel.name.startsWith('#mp_')">
+			<div class="messages-divider" *ngIf="selectedChannel != null && selectedChannel.name.startsWith('#mp_') && splitBanchoMessages == true">
 				<div class="divider-buttons">
 					<div class="divider-bigger" (click)="expandDivider()">
 						<mat-icon>expand_more</mat-icon>

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -36,6 +36,7 @@ import { ChallongeService } from 'app/services/challonge.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { SlashCommandService } from 'app/services/slash-command.service';
 import { SlashCommand } from 'app/models/slash-command';
+import { GenericService } from 'app/services/generic.service';
 
 @Component({
 	selector: 'app-irc',
@@ -62,6 +63,8 @@ export class IrcComponent implements OnInit {
 
 	banchoBotChats: IrcMessage[] = [];
 	banchoBotViewPortItems: IrcMessage[];
+
+	splitBanchoMessages: boolean;
 
 	chatLength = 0;
 	keyPressed = false;
@@ -116,7 +119,8 @@ export class IrcComponent implements OnInit {
 		public multiplayerLobbyPlayersService: MultiplayerLobbyPlayersService,
 		private tournamentService: TournamentService,
 		private challongeService: ChallongeService,
-		public slashCommandService: SlashCommandService) {
+		public slashCommandService: SlashCommandService,
+		private genericService: GenericService) {
 		this.channels = ircService.allChannels;
 
 		const dividerHeightStore = this.storeService.get('dividerHeight');
@@ -205,6 +209,10 @@ export class IrcComponent implements OnInit {
 
 		this.allSlashCommands = this.slashCommandService.getSlashCommands();
 		this.allSlashCommandsFiltered = this.slashCommandService.getSlashCommands();
+
+		this.genericService.getSplitBanchoMessages().subscribe(status => {
+			this.splitBanchoMessages = status;
+		});
 	}
 
 	/**

--- a/src/app/modules/settings/components/settings/settings.component.html
+++ b/src/app/modules/settings/components/settings/settings.component.html
@@ -123,5 +123,22 @@
 				<button mat-raised-button color="primary" (click)="option.action()">{{ option.buttonText }}</button>
 			</div>
 		</div>
+
+		<div class="option">
+			<div class="content">
+				<div class="icon">
+					<mat-icon>chat</mat-icon>
+				</div>
+
+				<div class="text">
+					<span>Split up the messages from Bancho and regular players in a multiplayer lobby.</span>
+				</div>
+			</div>
+
+			<div class="button">
+				{{ splitIrcMessages }}
+				<button mat-raised-button color="primary" (click)="toggleSplitIrcMessages()">{{ splitIrcMessages == true ? 'On' : 'Off' }}</button>
+			</div>
+		</div>
 	</div>
 </div>

--- a/src/app/modules/settings/components/settings/settings.component.ts
+++ b/src/app/modules/settings/components/settings/settings.component.ts
@@ -36,6 +36,8 @@ export class SettingsComponent implements OnInit {
 
 	axsMenuStatus: boolean;
 
+	splitIrcMessages: boolean;
+
 	allOptions: { icon: string; message: string; buttonText: string; action: any }[] = [
 		{ icon: 'settings', message: 'This will export the config file and save it as a file in case you need to share it with someone. <br /><b>Note:</b> This will not export any authentication data such as login information or API keys <br />', buttonText: 'Export config file', action: () => this.exportConfigFile() },
 		{ icon: 'cached', message: 'This will clear all the cache.', buttonText: 'Clear cache', action: () => this.openDialog(0) },
@@ -253,5 +255,10 @@ export class SettingsComponent implements OnInit {
 	toggleAxSMenu(): void {
 		this.axsMenuStatus = !this.axsMenuStatus;
 		this.genericService.setAxSMenu(this.axsMenuStatus);
+	}
+
+	toggleSplitIrcMessages(): void {
+		this.splitIrcMessages = !this.splitIrcMessages;
+		this.genericService.setSplitBanchoMessages(this.splitIrcMessages);
 	}
 }

--- a/src/app/services/generic.service.ts
+++ b/src/app/services/generic.service.ts
@@ -11,11 +11,15 @@ import { ToastService } from './toast.service';
 export class GenericService {
 	private showAxSMenu$: BehaviorSubject<boolean>;
 	private cacheCheck$: BehaviorSubject<boolean>;
+	private splitBanchoMessages$: BehaviorSubject<boolean>;
 
 	constructor(private storeService: StoreService, private apiKeyValidation: ApiKeyValidation, private toastService: ToastService) {
 		const showAxSMenu = this.storeService.get('show-axs');
+		const splitBanchoMessages = this.storeService.get('split-bancho-messages');
+
 		this.showAxSMenu$ = new BehaviorSubject(showAxSMenu == undefined ? false : showAxSMenu);
 		this.cacheCheck$ = new BehaviorSubject(false);
+		this.splitBanchoMessages$ = new BehaviorSubject(splitBanchoMessages == undefined ? false : splitBanchoMessages);
 
 		const apiKey = this.storeService.get('api-key');
 
@@ -64,5 +68,22 @@ export class GenericService {
 	 */
 	getCacheHasBeenChecked(): BehaviorSubject<boolean> {
 		return this.cacheCheck$;
+	}
+
+	/**
+	 * Split the Bancho messages or not
+	 *
+	 * @param active the status of the AxS menu
+	 */
+	setSplitBanchoMessages(active: boolean): void {
+		this.splitBanchoMessages$.next(active);
+		this.storeService.set('split-bancho-messages', active);
+	}
+
+	/**
+	 * Get the status of whether to split Bancho messages or not
+	 */
+	getSplitBanchoMessages(): BehaviorSubject<boolean> {
+		return this.splitBanchoMessages$;
 	}
 }

--- a/src/app/services/irc.service.ts
+++ b/src/app/services/irc.service.ts
@@ -13,6 +13,7 @@ import { WyModBracket } from 'app/models/wytournament/mappool/wy-mod-bracket';
 import { Lobby } from 'app/models/lobby';
 import { MultiplayerLobbyPlayersService } from './multiplayer-lobby-players.service';
 import { ElectronService } from './electron.service';
+import { GenericService } from './generic.service';
 
 @Injectable({
 	providedIn: 'root'
@@ -53,7 +54,8 @@ export class IrcService {
 		private storeService: StoreService,
 		private multiplayerLobbiesService: WyMultiplayerLobbiesService,
 		private multiplayerLobbyPlayersService: MultiplayerLobbyPlayersService,
-		private electronService: ElectronService) {
+		private electronService: ElectronService,
+		private genericService: GenericService) {
 		// Create observables for is(Dis)Connecting
 		this.isConnecting$ = new BehaviorSubject<boolean>(false);
 		this.isDisconnecting$ = new BehaviorSubject<boolean>(false);
@@ -412,9 +414,15 @@ export class IrcService {
 			}
 
 			if (user.startsWith('#mp_')) {
-				if (recipient == 'BanchoBot') {
-					channel.banchoBotMessages.push(newMessage);
-					this.saveMessageToHistory(user, newMessage, message, true);
+				if (this.genericService.getSplitBanchoMessages().value == true) {
+					if (recipient == 'BanchoBot') {
+						channel.banchoBotMessages.push(newMessage);
+						this.saveMessageToHistory(user, newMessage, message, true);
+					}
+					else {
+						channel.messages.push(newMessage);
+						this.saveMessageToHistory(user, newMessage, message);
+					}
 				}
 				else {
 					channel.messages.push(newMessage);


### PR DESCRIPTION
By default Banchobot messages were being split above the regular irc section
An option has been added that allows you to "disable" this and have it show up in the normal irc chat