### PR TITLE
Disable the check whether players are in the correct slot

### DIFF
--- a/src/app/services/irc.service.ts
+++ b/src/app/services/irc.service.ts
@@ -186,13 +186,14 @@ export class IrcService {
 					this.multiplayerLobbyPlayersService.lobbyChange(multiplayerLobby.lobbyId, 'playerInSlot', playerInSlot);
 
 					// Check if the player is in the correct slot
-					if (multiplayerLobby) {
-						if (multiplayerLobby.isQualifierLobby != true) {
-							if (!this.multiplayerLobbyPlayersService.isInCorrectSlot(playerInSlot.username, multiplayerLobby)) {
-								message.message += ` | Incorrect slot, player should be in slot ${multiplayerLobby.getCorrectSlot(playerInSlot.username)}`;
-							}
-						}
-					}
+					// TODO: Fix the isInCorrectSlot check, doesn't always work
+					// if (multiplayerLobby) {
+					// 	if (multiplayerLobby.isQualifierLobby != true) {
+					// 		if (!this.multiplayerLobbyPlayersService.isInCorrectSlot(playerInSlot.username, multiplayerLobby)) {
+					// 			message.message += ` | Incorrect slot, player should be in slot ${multiplayerLobby.getCorrectSlot(playerInSlot.username)}`;
+					// 		}
+					// 	}
+					// }
 				}
 			}
 


### PR DESCRIPTION
Disabled the check whether players are in the correct slot when `!mp settings` is ran, it shows that players are in the incorrect spots even if they are in the correct spots and the other way around. Will be enabled again once a proper fix has been made