### PR TITLE
Hide buttons in qualifier lobbies

### DIFF
--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -521,10 +521,10 @@
 							</div>
 
 							<div class="beatmap-actions">
-								<div class="beatmap-button warn" matTooltip="Ban this beatmap" *ngIf="!selectedLobby.beatmapIsBanned(beatmap.beatmapId)" (click)="banBeatmap(beatmap, bracket, selectedLobby)">
+								<div class="beatmap-button warn" matTooltip="Ban this beatmap" *ngIf="!selectedLobby.beatmapIsBanned(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="banBeatmap(beatmap, bracket, selectedLobby)">
 									<mat-icon svgIcon="hammer"></mat-icon>
 								</div>
-								<div class="beatmap-button accent" matTooltip="Unban this beatmap" *ngIf="selectedLobby.beatmapIsBanned(beatmap.beatmapId)" (click)="unbanBeatmap(beatmap)">
+								<div class="beatmap-button accent" matTooltip="Unban this beatmap" *ngIf="selectedLobby.beatmapIsBanned(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="unbanBeatmap(beatmap)">
 									<mat-icon>thumb_up</mat-icon>
 								</div>
 

--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -528,7 +528,7 @@
 									<mat-icon>thumb_up</mat-icon>
 								</div>
 
-								<div class="beatmap-button accent" matTooltip="Change which team has picked this map" *ngIf="selectedLobby.beatmapIsPicked(beatmap.beatmapId)" (click)="changePickedBy(beatmap)">
+								<div class="beatmap-button accent" matTooltip="Change which team has picked this map" *ngIf="selectedLobby.beatmapIsPicked(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="changePickedBy(beatmap)">
 									<mat-icon>change_circle</mat-icon>
 								</div>
 


### PR DESCRIPTION
The following buttons have been hidden in qualifier lobbies:
- The `Ban this beatmap` button
- The `Unban this beatmap` button
- The `Change which team has picked this map` button