### PR TITLE
Fix lobby name with brackets not being saved properly

### DIFF
--- a/src/app/modules/tournament-management/components/tournament-manage/tournament-published-edit/tournament-published-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-manage/tournament-published-edit/tournament-published-edit.component.ts
@@ -47,7 +47,8 @@ export class TournamentPublishedEditComponent implements OnInit {
 						Validators.max(8)
 					]),
 					'allow-double-pick': new FormControl(tournament.allowDoublePick),
-					'invalidate-beatmaps': new FormControl(tournament.invalidateBeatmaps)
+					'invalidate-beatmaps': new FormControl(tournament.invalidateBeatmaps),
+					'lobby-team-name-with-brackets': new FormControl(tournament.lobbyTeamNameWithBrackets)
 				});
 
 				const calculateScoreInterfaces: Calculate = new Calculate();


### PR DESCRIPTION
Fix the toggle to create a lobby with or without brackets around the team names