### PR TITLE
Protects

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { SidebarComponent } from './layout/sidebar/sidebar.component';
 import { UpdaterComponent } from './layout/updater/updater.component';
 import { MarkdownModule } from 'ngx-markdown';
 import { CredentialsInterceptor } from './core/interceptors/credentials.interceptor';
+import { ProtectBeatmapDialogComponent } from './components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component';
 
 @NgModule({
 	declarations: [
@@ -53,6 +54,7 @@ import { CredentialsInterceptor } from './core/interceptors/credentials.intercep
 		IrcShortcutDialogComponent,
 		IrcPickMapSameModBracketComponent,
 		IrcShortcutWarningDialogComponent,
+		ProtectBeatmapDialogComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component.html
+++ b/src/app/components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component.html
@@ -1,0 +1,19 @@
+<h2 mat-dialog-title>Protect beatmap</h2>
+
+<mat-dialog-content class="mat-typography">
+	<div>
+		Select what team is protecting <a [routerLink]="[]" (click)="electronService.openLink(data.beatmap.beatmapUrl)"><b>{{ data.beatmap.beatmapName }}</b></a>
+	</div>
+
+	<hr />
+
+	<mat-button-toggle-group (change)="teamChange($event)">
+		<mat-button-toggle [value]="data.multiplayerLobby.teamOneName">{{ data.multiplayerLobby.teamOneName }}</mat-button-toggle>
+		<mat-button-toggle [value]="data.multiplayerLobby.teamTwoName">{{ data.multiplayerLobby.teamTwoName }}</mat-button-toggle>
+	  </mat-button-toggle-group>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+	<button mat-button [mat-dialog-close]="null">Cancel</button>
+	<button mat-button [mat-dialog-close]="data" color="warn" [disabled]="data.protectForTeam == null">Protect</button>
+</mat-dialog-actions>

--- a/src/app/components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component.spec.ts
+++ b/src/app/components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProtectBeatmapDialogComponent } from './protect-beatmap-dialog.component';
+
+describe('ProtectBeatmapDialogComponent', () => {
+	let component: ProtectBeatmapDialogComponent;
+	let fixture: ComponentFixture<ProtectBeatmapDialogComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [ProtectBeatmapDialogComponent]
+		})
+			.compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(ProtectBeatmapDialogComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component.ts
+++ b/src/app/components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component.ts
@@ -1,0 +1,19 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatButtonToggleChange } from '@angular/material/button-toggle';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { IProtectBeatmapDialogData } from 'app/interfaces/i-protect-beatmap-dialog-data';
+import { ElectronService } from 'app/services/electron.service';
+
+@Component({
+	selector: 'app-protect-beatmap-dialog',
+	templateUrl: './protect-beatmap-dialog.component.html',
+	styleUrls: ['./protect-beatmap-dialog.component.scss']
+})
+export class ProtectBeatmapDialogComponent implements OnInit {
+	constructor(@Inject(MAT_DIALOG_DATA) public data: IProtectBeatmapDialogData, public electronService: ElectronService) { }
+	ngOnInit(): void { }
+
+	teamChange(event: MatButtonToggleChange) {
+		this.data.protectForTeam = event.value;
+	}
+}

--- a/src/app/interfaces/i-protect-beatmap-dialog-data.ts
+++ b/src/app/interfaces/i-protect-beatmap-dialog-data.ts
@@ -1,0 +1,11 @@
+import { Lobby } from "app/models/lobby";
+import { WyModBracket } from "app/models/wytournament/mappool/wy-mod-bracket";
+import { WyModBracketMap } from "app/models/wytournament/mappool/wy-mod-bracket-map";
+
+export interface IProtectBeatmapDialogData {
+	beatmap: WyModBracketMap;
+	modBracket: WyModBracket;
+	multiplayerLobby: Lobby;
+
+	protectForTeam: string;
+}

--- a/src/app/interfaces/i-protect-beatmap-dialog-data.ts
+++ b/src/app/interfaces/i-protect-beatmap-dialog-data.ts
@@ -1,6 +1,6 @@
-import { Lobby } from "app/models/lobby";
-import { WyModBracket } from "app/models/wytournament/mappool/wy-mod-bracket";
-import { WyModBracketMap } from "app/models/wytournament/mappool/wy-mod-bracket-map";
+import { Lobby } from 'app/models/lobby';
+import { WyModBracket } from 'app/models/wytournament/mappool/wy-mod-bracket';
+import { WyModBracketMap } from 'app/models/wytournament/mappool/wy-mod-bracket-map';
 
 export interface IProtectBeatmapDialogData {
 	beatmap: WyModBracketMap;

--- a/src/app/models/lobby.ts
+++ b/src/app/models/lobby.ts
@@ -59,6 +59,9 @@ export class Lobby {
 	teamOneBans: number[];
 	teamTwoBans: number[];
 
+	teamOneProtects: number[];
+	teamTwoProtects: number[];
+
 	teamOnePicks: number[];
 	teamTwoPicks: number[];
 
@@ -81,6 +84,9 @@ export class Lobby {
 	constructor(init?: Partial<Lobby>) {
 		this.teamOneBans = [];
 		this.teamTwoBans = [];
+
+		this.teamOneProtects = [];
+		this.teamTwoProtects = [];
 
 		this.teamOnePicks = [];
 		this.teamTwoPicks = [];
@@ -143,6 +149,8 @@ export class Lobby {
 			teamTwoOverwriteHealth: !isNaN(lobby.teamTwoOverwriteHealth) ? lobby.teamTwoOverwriteScore : 0,
 			teamOneBans: lobby.teamOneBans,
 			teamTwoBans: lobby.teamTwoBans,
+			teamOneProtects: lobby.teamOneProtects == undefined ? [] : lobby.teamOneProtects,
+			teamTwoProtects: lobby.teamTwoProtects == undefined ? [] : lobby.teamTwoProtects,
 			teamOnePicks: lobby.teamOnePicks,
 			teamTwoPicks: lobby.teamTwoPicks,
 			gamesCountTowardsScore: lobby.gamesCountTowardsScore,
@@ -382,7 +390,7 @@ export class Lobby {
 	}
 
 	/**
-	 * Check if a beatmap is banned int he current lobby
+	 * Check if a beatmap is banned in the current lobby
 	 *
 	 * @param beatmapId the beatmap to check
 	 */
@@ -406,6 +414,33 @@ export class Lobby {
 	 */
 	beatmapIsBannedByTeamTwo(beatmapId: number) {
 		return this.teamTwoBans.indexOf(beatmapId) > -1;
+	}
+
+	/**
+	 * Check if a beatmap is protected in the current lobby
+	 *
+	 * @param beatmapId the beatmap to check
+	 */
+	beatmapIsProtected(beatmapId: number) {
+		return this.teamOneProtects.indexOf(beatmapId) > -1 || this.teamTwoProtects.indexOf(beatmapId) > -1;
+	}
+
+	/**
+	 * Check if the beatmap is protected by team one
+	 *
+	 * @param beatmapId the beatmap to check
+	 */
+	beatmapIsProtectedByTeamOne(beatmapId: number) {
+		return this.teamOneProtects.indexOf(beatmapId) > -1;
+	}
+
+	/**
+	 * Check if the beatmap is protected by team two
+	 *
+	 * @param beatmapId the beatmap to check
+	 */
+	beatmapIsProtectedByTeamTwo(beatmapId: number) {
+		return this.teamTwoProtects.indexOf(beatmapId) > -1;
 	}
 
 	/**

--- a/src/app/models/wytournament/wy-tournament.ts
+++ b/src/app/models/wytournament/wy-tournament.ts
@@ -20,6 +20,7 @@ export class WyTournament {
 	name: string;
 	acronym: string;
 	gamemodeId: number;
+	protects: boolean;
 	teamSize: number;
 	format: TournamentFormat;
 
@@ -88,6 +89,7 @@ export class WyTournament {
 			name: tournament.name,
 			acronym: tournament.acronym,
 			gamemodeId: tournament.gamemodeId,
+			protects: tournament.protects,
 			teamSize: tournament.teamSize,
 			format: tournament.format,
 			scoreInterface: calc.getScoreInterface(tournament.scoreInterfaceIdentifier),

--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -579,7 +579,15 @@
 									<mat-icon>thumb_up</mat-icon>
 								</div>
 
-								<div class="beatmap-button accent" matTooltip="Change which team has picked this map" *ngIf="selectedLobby.beatmapIsPicked(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="changePickedBy(beatmap)">
+								<div class="beatmap-button accent" matTooltip="Protect this beatmap" *ngIf="!selectedLobby.beatmapIsProtected(beatmap.beatmapId) && selectedLobby.tournament.protects == true && selectedLobby.isQualifierLobby == false" (click)="protectBeatmap(beatmap, bracket, selectedLobby)">
+									<mat-icon>shield</mat-icon>
+								</div>
+
+								<div class="beatmap-button danger" matTooltip="Unprotect this beatmap" *ngIf="selectedLobby.beatmapIsProtected(beatmap.beatmapId) && selectedLobby.tournament.protects == true && selectedLobby.isQualifierLobby == false" (click)="unprotectBeatmap(beatmap)">
+									<mat-icon>remove_moderator</mat-icon>
+								</div>
+
+								<div class="beatmap-button accent" matTooltip="Change which team has picked this beatmap" *ngIf="selectedLobby.beatmapIsPicked(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="changePickedBy(beatmap)">
 									<mat-icon>change_circle</mat-icon>
 								</div>
 

--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -572,14 +572,14 @@
 							</div>
 
 							<div class="beatmap-actions">
-								<div class="beatmap-button warn" matTooltip="Ban this beatmap" *ngIf="!selectedLobby.beatmapIsBanned(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="banBeatmap(beatmap, bracket, selectedLobby)">
+								<div class="beatmap-button warn" matTooltip="Ban this beatmap" *ngIf="!selectedLobby.beatmapIsBanned(beatmap.beatmapId) && !selectedLobby.beatmapIsProtected(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="banBeatmap(beatmap, bracket, selectedLobby)">
 									<mat-icon svgIcon="hammer"></mat-icon>
 								</div>
 								<div class="beatmap-button accent" matTooltip="Unban this beatmap" *ngIf="selectedLobby.beatmapIsBanned(beatmap.beatmapId) && selectedLobby.isQualifierLobby == false" (click)="unbanBeatmap(beatmap)">
 									<mat-icon>thumb_up</mat-icon>
 								</div>
 
-								<div class="beatmap-button accent" matTooltip="Protect this beatmap" *ngIf="!selectedLobby.beatmapIsProtected(beatmap.beatmapId) && selectedLobby.tournament.protects == true && selectedLobby.isQualifierLobby == false" (click)="protectBeatmap(beatmap, bracket, selectedLobby)">
+								<div class="beatmap-button accent" matTooltip="Protect this beatmap" *ngIf="!selectedLobby.beatmapIsProtected(beatmap.beatmapId) && !selectedLobby.beatmapIsBanned(beatmap.beatmapId)  && selectedLobby.tournament.protects == true && selectedLobby.isQualifierLobby == false" (click)="protectBeatmap(beatmap, bracket, selectedLobby)">
 									<mat-icon>shield</mat-icon>
 								</div>
 

--- a/src/app/modules/irc/components/irc/irc.component.scss
+++ b/src/app/modules/irc/components/irc/irc.component.scss
@@ -1000,6 +1000,16 @@ $hyperlink-background-color: #2b4576;
 										}
 									}
 
+									&.danger {
+										color: white;
+										background-color: $danger;
+
+										&:hover {
+											background-color: darken($danger, 15%);
+											cursor: pointer;
+										}
+									}
+
 									&.accent {
 										background-color: $success;
 

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -496,6 +496,11 @@ export class IrcComponent implements OnInit {
 	 * @param bracket the bracket where the beatmap is from
 	 */
 	pickBeatmap(beatmap: WyModBracketMap, bracket: WyModBracket, gamemode: number, forcePick = false) {
+		// Check whether the beatmap is banned
+		if(this.selectedLobby.beatmapIsBanned(beatmap.beatmapId)) {
+			return;
+		}
+
 		// Prevent picking when firstPick isn't set
 		if (this.selectedLobby.firstPick == undefined && (this.selectedLobby.isQualifierLobby == undefined || this.selectedLobby.isQualifierLobby == false)) {
 			this.toastService.addToast('You haven\'t set who picks first yet.', ToastType.Error);

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -37,6 +37,8 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { SlashCommandService } from 'app/services/slash-command.service';
 import { SlashCommand } from 'app/models/slash-command';
 import { GenericService } from 'app/services/generic.service';
+import { ProtectBeatmapDialogComponent } from 'app/components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component';
+import { IProtectBeatmapDialogData } from 'app/interfaces/i-protect-beatmap-dialog-data';
 
 @Component({
 	selector: 'app-irc',
@@ -790,6 +792,71 @@ export class IrcComponent implements OnInit {
 	}
 
 	/**
+	 * Unban a beatmap
+	 *
+	 * @param beatmap
+	 * @param bracket
+	 */
+	unbanBeatmap(beatmap: WyModBracketMap) {
+		if (this.selectedLobby.teamOneBans.indexOf(beatmap.beatmapId) > -1) {
+			this.selectedLobby.teamOneBans.splice(this.selectedLobby.teamOneBans.indexOf(beatmap.beatmapId), 1);
+		}
+		else if (this.selectedLobby.teamTwoBans.indexOf(beatmap.beatmapId) > -1) {
+			this.selectedLobby.teamTwoBans.splice(this.selectedLobby.teamTwoBans.indexOf(beatmap.beatmapId), 1);
+		}
+
+		this.multiplayerLobbies.updateMultiplayerLobby(this.selectedLobby);
+	}
+
+	/**
+	 * Protect the given beatmap
+	 *
+	 * @param beatmap the beatmap to protect
+	 * @param modBracket the mod bracket the beatmap belongs to
+	 * @param multiplayerLobby the lobby the beatmap should be protected in
+	 */
+	protectBeatmap(beatmap: WyModBracketMap, modBracket: WyModBracket, multiplayerLobby: Lobby) {
+		const dialogRef = this.dialog.open(ProtectBeatmapDialogComponent, {
+			data: {
+				beatmap: beatmap,
+				modBracket: modBracket,
+				multiplayerLobby: multiplayerLobby
+			}
+		});
+
+		dialogRef.afterClosed().subscribe((result: IProtectBeatmapDialogData) => {
+			if (result != null) {
+				if (result.protectForTeam == result.multiplayerLobby.teamOneName) {
+					this.selectedLobby.teamOneProtects.push(result.beatmap.beatmapId);
+					this.webhookService.sendProtectResult(result.multiplayerLobby, result.multiplayerLobby.teamOneName, result.beatmap, this.ircService.authenticatedUser);
+				}
+				else {
+					this.selectedLobby.teamTwoProtects.push(result.beatmap.beatmapId);
+					this.webhookService.sendProtectResult(result.multiplayerLobby, result.multiplayerLobby.teamTwoName, result.beatmap, this.ircService.authenticatedUser);
+				}
+
+				this.multiplayerLobbies.updateMultiplayerLobby(this.selectedLobby);
+			}
+		});
+	}
+
+	/**
+	 * Unprotect a beatmap
+	 *
+	 * @param beatmap the beatmap to unprotect
+	 */
+	unprotectBeatmap(beatmap: WyModBracketMap) {
+		if (this.selectedLobby.teamOneProtects.indexOf(beatmap.beatmapId) > -1) {
+			this.selectedLobby.teamOneProtects.splice(this.selectedLobby.teamOneProtects.indexOf(beatmap.beatmapId), 1);
+		}
+		else if (this.selectedLobby.teamTwoProtects.indexOf(beatmap.beatmapId) > -1) {
+			this.selectedLobby.teamTwoProtects.splice(this.selectedLobby.teamTwoProtects.indexOf(beatmap.beatmapId), 1);
+		}
+
+		this.multiplayerLobbies.updateMultiplayerLobby(this.selectedLobby);
+	}
+
+	/**
 	 * Check if a beatmap has been picked by team one in the current lobby
 	 *
 	 * @param multiplayerLobby the multiplayerlobby to check from
@@ -807,23 +874,6 @@ export class IrcComponent implements OnInit {
 	 */
 	beatmapIsPickedByTeamTwo(multiplayerLobby: Lobby, beatmapId: number) {
 		return multiplayerLobby.teamTwoPicks != null && multiplayerLobby.teamTwoPicks.indexOf(beatmapId) > -1;
-	}
-
-	/**
-	 * Unban a beatmap
-	 *
-	 * @param beatmap
-	 * @param bracket
-	 */
-	unbanBeatmap(beatmap: WyModBracketMap) {
-		if (this.selectedLobby.teamOneBans.indexOf(beatmap.beatmapId) > -1) {
-			this.selectedLobby.teamOneBans.splice(this.selectedLobby.teamOneBans.indexOf(beatmap.beatmapId), 1);
-		}
-		else if (this.selectedLobby.teamTwoBans.indexOf(beatmap.beatmapId) > -1) {
-			this.selectedLobby.teamTwoBans.splice(this.selectedLobby.teamTwoBans.indexOf(beatmap.beatmapId), 1);
-		}
-
-		this.multiplayerLobbies.updateMultiplayerLobby(this.selectedLobby);
 	}
 
 	/**

--- a/src/app/modules/tournament-management/components-utility/tournament/tournament-general/tournament-general.component.html
+++ b/src/app/modules/tournament-management/components-utility/tournament/tournament-general/tournament-general.component.html
@@ -52,6 +52,26 @@
 		</div>
 	</div>
 
+	<div class="row">
+		<div class="col">
+			<h3>Protects</h3>
+
+			<mat-form-field class="full-width">
+				<mat-label>Protects</mat-label>
+				<mat-select formControlName="tournament-protects" (selectionChange)="changeProtects($event)">
+					<mat-option [value]="true">True</mat-option>
+					<mat-option [value]="false">False</mat-option>
+				</mat-select>
+
+				<mat-error *ngIf="validationForm.get('tournament-protects').errors && (validationForm.get('tournament-protects').touched || validationForm.get('tournament-protects').dirty)">
+					This field is required
+				</mat-error>
+			</mat-form-field>
+
+			<p>Whether the tournament uses protects. Protecting a beatmap will prevent a team from banning the given beatmap.</p>
+		</div>
+	</div>
+
 	<hr />
 
 	<div class="row r-3">

--- a/src/app/modules/tournament-management/components-utility/tournament/tournament-general/tournament-general.component.ts
+++ b/src/app/modules/tournament-management/components-utility/tournament/tournament-general/tournament-general.component.ts
@@ -49,6 +49,14 @@ export class TournamentGeneralComponent implements OnInit {
 	}
 
 	/**
+	 * Change whether the tournament uses protects
+	 */
+	changeProtects(event: MatSelectChange): void {
+		this.validationForm.get('tournament-protects').setValue(event.value);
+		this.tournament.protects = event.value;
+	}
+
+	/**
 	 * Change the tournament format (solo or teams)
 	 */
 	changeTeamFormat(event: MatSelectChange): void {

--- a/src/app/modules/tournament-management/components/tournament-manage/tournament-create/tournament-create.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-manage/tournament-create/tournament-create.component.ts
@@ -32,6 +32,9 @@ export class TournamentCreateComponent implements OnInit {
 			'tournament-score-system': new FormControl('', [
 				Validators.required
 			]),
+			'tournament-protects': new FormControl('', [
+				Validators.required
+			]),
 			'tournament-format': new FormControl('', [
 				Validators.required
 			]),

--- a/src/app/modules/tournament-management/components/tournament-manage/tournament-edit/tournament-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-manage/tournament-edit/tournament-edit.component.ts
@@ -39,6 +39,9 @@ export class TournamentEditComponent implements OnInit {
 						'tournament-score-system': new FormControl('', [
 							Validators.required
 						]),
+						'tournament-protects': new FormControl(tournament.protects, [
+							Validators.required
+						]),
 						'tournament-format': new FormControl(tournament.format, [
 							Validators.required
 						]),

--- a/src/app/modules/tournament-management/components/tournament-manage/tournament-published-edit/tournament-published-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-manage/tournament-published-edit/tournament-published-edit.component.ts
@@ -38,6 +38,9 @@ export class TournamentPublishedEditComponent implements OnInit {
 					'tournament-score-system': new FormControl('', [
 						Validators.required
 					]),
+					'tournament-protects': new FormControl(tournament.protects, [
+						Validators.required
+					]),
 					'tournament-format': new FormControl(tournament.format, [
 						Validators.required
 					]),

--- a/src/app/services/webhook.service.ts
+++ b/src/app/services/webhook.service.ts
@@ -312,6 +312,48 @@ export class WebhookService {
 	}
 
 	/**
+	 * Send the protect through a discord webhook
+	 *
+	 * @param selectedLobby the lobby to get the data from
+	 * @param teamName the name of the banner
+	 * @param protect the map that was protected
+	 * @param referee the referee
+	 */
+	sendProtectResult(selectedLobby: Lobby, teamName: string, protect: WyModBracketMap, referee: string) {
+		// Dont send webhooks if its disabled
+		if (!this.doSendWebhooks(selectedLobby)) {
+			return;
+		}
+
+		const body = {
+			embeds: [
+				{
+					title: `🛡 Protect update - ${selectedLobby.teamOneName} vs ${selectedLobby.teamTwoName}`,
+					url: selectedLobby.multiplayerLink,
+					description: `**${teamName}** has protected [**${protect.beatmapName}**](${protect.beatmapUrl})`,
+					color: 15258703,
+					footer: {
+						text: `Match referee was ${referee}`
+					},
+					thumbnail: {
+						url: `https://b.ppy.sh/thumb/${protect.beatmapsetId}.jpg`
+					},
+					fields: [
+					]
+				}
+			]
+		};
+
+		this.setCustomizedFields(body, false);
+
+		for (const webhook of selectedLobby.tournament.webhooks) {
+			if (webhook.bans == true) {
+				this.http.post(webhook.url, body, { headers: new HttpHeaders({ 'Content-type': 'application/json' }) }).subscribe();
+			}
+		}
+	}
+
+	/**
 	 * Send a summary of the match through a discord webhook
 	 *
 	 * @param selectedLobby the lobby to get the data from


### PR DESCRIPTION
Implements protects

- Allow a referee to select which beatmaps are protected
- When a beatmap is protected, it can no longer be banned
- Send a webhook when a beatmap is protected by a player/team
- Fixed a bug where banned beatmaps could still be picked

Closes #107