### PR TITLE
Remove ban check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wyreferee",
-	"version": "6.6.3",
+	"version": "6.6.4",
 	"description": "Referee client",
 	"author": {
 		"name": "Wesley"

--- a/src/app/modules/irc/components/irc/irc.component.ts
+++ b/src/app/modules/irc/components/irc/irc.component.ts
@@ -520,24 +520,24 @@ export class IrcComponent implements OnInit {
 			return;
 		}
 
-		// Prevent picking when the not enough maps have been banned
-		if (this.selectedLobby.banCount != undefined && this.selectedLobby.banCount != null) {
-			let bansNotMet = false;
+		// // Prevent picking when the not enough maps have been banned
+		// if (this.selectedLobby.banCount != undefined && this.selectedLobby.banCount != null) {
+		// 	let bansNotMet = false;
 
-			if (this.selectedLobby.teamOneBans.length < this.selectedLobby.banCount) {
-				this.toastService.addToast(`${this.selectedLobby.teamOneName} has not banned ${this.selectedLobby.banCount} map(s) yet.`, ToastType.Error, 10);
-				bansNotMet = true;
-			}
+		// 	if (this.selectedLobby.teamOneBans.length < this.selectedLobby.banCount) {
+		// 		this.toastService.addToast(`${this.selectedLobby.teamOneName} has not banned ${this.selectedLobby.banCount} map(s) yet.`, ToastType.Error, 10);
+		// 		bansNotMet = true;
+		// 	}
 
-			if (this.selectedLobby.teamTwoBans.length < this.selectedLobby.banCount) {
-				this.toastService.addToast(`${this.selectedLobby.teamTwoName} has not banned ${this.selectedLobby.banCount} map(s) yet.`, ToastType.Error, 10);
-				bansNotMet = true;
-			}
+		// 	if (this.selectedLobby.teamTwoBans.length < this.selectedLobby.banCount) {
+		// 		this.toastService.addToast(`${this.selectedLobby.teamTwoName} has not banned ${this.selectedLobby.banCount} map(s) yet.`, ToastType.Error, 10);
+		// 		bansNotMet = true;
+		// 	}
 
-			if (bansNotMet == true) {
-				return;
-			}
-		}
+		// 	if (bansNotMet == true) {
+		// 		return;
+		// 	}
+		// }
 
 		// Check if teams are allowed to pick from the same modbracket twice in a row
 		if (this.selectedLobby.tournament.allowDoublePick == false) {


### PR DESCRIPTION
Temporarily remove the ban check before picking a map, forgot about tournaments having delayed bans (2nd ban after x points lost), preventing the client from continuing the match because of not enough bans have been banned at the start