### PR TITLE
Catch The Magic changes

### DIFF
--- a/src/app/models/score-calculation/calculate.ts
+++ b/src/app/models/score-calculation/calculate.ts
@@ -17,7 +17,7 @@ export class Calculate {
 		this.addScoreInterface(new AxSCalculation('AxS', 3));
 		this.addScoreInterface(new ThreeCwcScoreCalculation('osu!catch 3 Digit World Cup', 3));
 		this.addScoreInterface(new OMLScoreCalculation('osu!catch Master League', 2));
-		this.addScoreInterface(new CTMCalculation('CTM4', 3));
+		this.addScoreInterface(new CTMCalculation('CTM'));
 	}
 
 	/**

--- a/src/app/services/wy-multiplayer-lobbies.service.ts
+++ b/src/app/services/wy-multiplayer-lobbies.service.ts
@@ -282,14 +282,10 @@ export class WyMultiplayerLobbiesService {
 				}
 
 				// Provide the mod bracket to the interface
-				if (scoreInterface instanceof ThreeCwcScoreCalculation || scoreInterface instanceof OMLScoreCalculation) {
+				if (scoreInterface instanceof ThreeCwcScoreCalculation || scoreInterface instanceof OMLScoreCalculation || scoreInterface instanceof CTMCalculation) {
 					if (foundModBracket) {
 						scoreInterface.setModBracket(foundModBracket);
 					}
-				}
-
-				if (scoreInterface instanceof CTMCalculation) {
-					scoreInterface.setBeatmap(foundModBracketBeatmap);
 				}
 
 				multiplayerData.team_one_score = scoreInterface.calculateTeamOneScore();


### PR DESCRIPTION
Changes the score system of Catch The Magic

**The following changes only apply to the Freemod mod bracket**
- Sudden Death, Hidden, Doubletime and Hardrock all give 60000 bonus score
- Easy gives 440000 bonus score