### PR TITLE
Add mania template for mod bracket generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wyreferee",
-	"version": "6.6.8",
+	"version": "6.6.9",
 	"description": "Referee client",
 	"author": {
 		"name": "Wesley"

--- a/src/app/modules/tournament-management/components-utility/tournament/tournament-mappool/mappool/mappool.component.ts
+++ b/src/app/modules/tournament-management/components-utility/tournament/tournament-mappool/mappool/mappool.component.ts
@@ -117,28 +117,36 @@ export class MappoolComponent implements OnInit {
 	 * @param nofail whether or not to add NoFail to the brackets
 	 */
 	createDefaultBrackets(nofail: boolean): void {
-		if (nofail) {
-			this.createDefaultBracket('Nomod', 'NM', [{ name: 'Nofail', value: Mods.NoFail }]);
-			this.createDefaultBracket('Hidden', 'HD', [{ name: 'Hidden', value: Mods.Hidden }, { name: 'Nofail', value: Mods.NoFail }]);
-
-			if (this.tournament.gamemodeId != Gamemodes.Catch) {
-				this.createDefaultBracket('Hardrock', 'HR', [{ name: 'Hardrock', value: Mods.HardRock }, { name: 'Nofail', value: Mods.NoFail }]);
-				this.createDefaultBracket('Doubletime', 'DT', [{ name: 'Doubletime', value: Mods.DoubleTime }, { name: 'Nofail', value: Mods.NoFail }]);
-			}
+		if (this.tournament.gamemodeId == Gamemodes.Mania) {
+			this.createDefaultBracket('Rice', 'RC', [{ name: 'Freemod', value: 'freemod' }]);
+			this.createDefaultBracket('Long Note', 'LN', [{ name: 'Freemod', value: 'freemod' }]);
+			this.createDefaultBracket('Hybrid', 'HB', [{ name: 'Freemod', value: 'freemod' }]);
+			this.createDefaultBracket('Speed Velocity ', 'TB', [{ name: 'Freemod', value: 'freemod' }]);
 		}
 		else {
-			this.createDefaultBracket('Nomod', 'NM', [{ name: 'Nomod', value: Mods.None }]);
-			this.createDefaultBracket('Hidden', 'HD', [{ name: 'Hidden', value: Mods.Hidden }]);
+			if (nofail) {
+				this.createDefaultBracket('Nomod', 'NM', [{ name: 'Nofail', value: Mods.NoFail }]);
+				this.createDefaultBracket('Hidden', 'HD', [{ name: 'Hidden', value: Mods.Hidden }, { name: 'Nofail', value: Mods.NoFail }]);
 
-			if (this.tournament.gamemodeId != Gamemodes.Catch) {
-				this.createDefaultBracket('Hardrock', 'HR', [{ name: 'Hardrock', value: Mods.HardRock }]);
-				this.createDefaultBracket('Doubletime', 'DT', [{ name: 'Doubletime', value: Mods.DoubleTime }]);
+				if (this.tournament.gamemodeId != Gamemodes.Catch) {
+					this.createDefaultBracket('Hardrock', 'HR', [{ name: 'Hardrock', value: Mods.HardRock }, { name: 'Nofail', value: Mods.NoFail }]);
+					this.createDefaultBracket('Doubletime', 'DT', [{ name: 'Doubletime', value: Mods.DoubleTime }, { name: 'Nofail', value: Mods.NoFail }]);
+				}
 			}
-		}
+			else {
+				this.createDefaultBracket('Nomod', 'NM', [{ name: 'Nomod', value: Mods.None }]);
+				this.createDefaultBracket('Hidden', 'HD', [{ name: 'Hidden', value: Mods.Hidden }]);
 
-		if (this.tournament.gamemodeId == Gamemodes.Catch) {
-			this.createDefaultBracket('Hardrock', 'HR', [{ name: 'Freemod', value: 'freemod' }]);
-			this.createDefaultBracket('Doubletime', 'DT', [{ name: 'Doubletime', value: Mods.DoubleTime }, { name: 'Freemod', value: 'freemod' }]);
+				if (this.tournament.gamemodeId != Gamemodes.Catch) {
+					this.createDefaultBracket('Hardrock', 'HR', [{ name: 'Hardrock', value: Mods.HardRock }]);
+					this.createDefaultBracket('Doubletime', 'DT', [{ name: 'Doubletime', value: Mods.DoubleTime }]);
+				}
+			}
+
+			if (this.tournament.gamemodeId == Gamemodes.Catch) {
+				this.createDefaultBracket('Hardrock', 'HR', [{ name: 'Freemod', value: 'freemod' }]);
+				this.createDefaultBracket('Doubletime', 'DT', [{ name: 'Doubletime', value: Mods.DoubleTime }, { name: 'Freemod', value: 'freemod' }]);
+			}
 		}
 
 		this.createDefaultBracket('Tiebreaker', 'TB', [{ name: 'Freemod', value: 'freemod' }]);


### PR DESCRIPTION
Adds the follow mod brackets when generating mod brackets for a mania tournament: 
- Rice - RC
- Long Note - LN
- Hybrid - HB
- Speed Velocity - SV
- Tiebreaker - TB

All mod brackets have Freemod enabled by default