### PR TITLE
Fix qualifier lobby not updating properly

### DIFF
--- a/src/app/services/wybin.service.ts
+++ b/src/app/services/wybin.service.ts
@@ -16,7 +16,7 @@ export class WybinService {
 
 	importStaff(tournamentId: number) {
 		return this.http.get(`${this.API_URL}tournament-staff-member/${tournamentId}`);
-  }
+	}
 
 	getMatch(tournamentId: number, stageName: string, opponentOne: string, opponentTwo: string) {
 		return this.http.post(`${this.API_URL}tournament-wyreferee-match`, {
@@ -27,7 +27,7 @@ export class WybinService {
 		});
 	}
 
-	updateMatchScore(tournamentId: number, stageName: string, multiplayerLink: string, opponentOne: string, opponentTwo: string, opponentOneScore: number, opponentTwoScore: number, winByDefaultWinner: string, opponentOneBans: number[], opponentTwoBans: number[]) {
+	updateMatchScore(tournamentId: number, stageName: string, multiplayerLink: string, opponentOne: string, opponentTwo: string, opponentOneScore: number, opponentTwoScore: number, winByDefaultWinner: string, opponentOneBans: number[], opponentTwoBans: number[], qualifierIdentifier?: string) {
 		return this.http.post(`${this.API_URL}tournament-wyreferee-score-update`, {
 			tournamentId: tournamentId,
 			stageName: stageName,
@@ -38,7 +38,8 @@ export class WybinService {
 			opponentTwoScore: opponentTwoScore,
 			winByDefaultWinner: winByDefaultWinner,
 			opponentOneBans: opponentOneBans,
-			opponentTwoBans: opponentTwoBans
+			opponentTwoBans: opponentTwoBans,
+			qualifierIdentifier: qualifierIdentifier
 		});
 	}
 }


### PR DESCRIPTION
Fixed an issue where it would only update data on the first Qualifier match on wyBin (regardless of which lobby you are refereeing) when you would send the final result in the IRC view