### PR TITLE
Multiplayer lobby creation fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wyreferee",
-	"version": "6.9.4",
+	"version": "6.9.5",
 	"description": "Referee client",
 	"author": {
 		"name": "Wesley"
@@ -99,7 +99,7 @@
 	"dependencies": {
 		"@angular/animations": "13.3.2",
 		"@angular/material": "13.3.2",
-		"bancho.js": "^0.9.7",
+		"bancho.js": "^0.12.0",
 		"electron-log": "^3.0.8",
 		"electron-store": "^5.0.0",
 		"electron-updater": "^4.1.2",

--- a/src/app/models/lobby.ts
+++ b/src/app/models/lobby.ts
@@ -577,6 +577,20 @@ export class Lobby {
 	}
 
 	/**
+	 * Get the escaped name from team one
+	 */
+	getEscapedTeamOneName(): string {
+		return this.teamOneName.replace(/[\p{Emoji_Presentation}\p{Emoji}\uFE0F]/gu, '');
+	}
+
+	/**
+	 * Get the escaped name from team two
+	 */
+	getEscapedTeamTwoName(): string {
+		return this.teamTwoName.replace(/[\p{Emoji_Presentation}\p{Emoji}\uFE0F]/gu, '');
+	}
+
+	/**
 	 * Calculate the score of team one with score overwriting
 	 */
 	getTeamOneScore(): number {

--- a/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
+++ b/src/app/modules/lobby/components/create-lobby/create-lobby.component.ts
@@ -161,10 +161,10 @@ export class CreateLobbyComponent implements OnInit {
 				if (lobby.tournament == undefined || lobby.tournament == null) {
 					const acronym: string = this.validationForm.get('tournament-acronym').value;
 
-					lobbyName = lobbyForm.qualifier == true ? `${acronym}: Qualifier lobby: ${lobbyForm.qualifierLobbyIdentifier}` : lobbyForm.lobbyWithBrackets == true ? `${acronym}: (${lobby.teamOneName}) vs (${lobby.teamTwoName})` : `${acronym}: ${lobby.teamOneName} vs ${lobby.teamTwoName}`;
+					lobbyName = lobbyForm.qualifier == true ? `${acronym}: Qualifier lobby: ${lobbyForm.qualifierLobbyIdentifier}` : lobbyForm.lobbyWithBrackets == true ? `${acronym}: (${lobby.getEscapedTeamOneName()}) vs (${lobby.getEscapedTeamTwoName()})` : `${acronym}: ${lobby.getEscapedTeamOneName()} vs ${lobby.getEscapedTeamTwoName()}`;
 				}
 				else {
-					lobbyName = lobbyForm.qualifier == true ? `${lobby.tournament.acronym}: Qualifier lobby: ${lobbyForm.qualifierLobbyIdentifier}` : lobbyForm.lobbyWithBrackets == true ? `${lobby.tournament.acronym}: (${lobby.teamOneName}) vs (${lobby.teamTwoName})` : `${lobby.tournament.acronym}: ${lobby.teamOneName} vs ${lobby.teamTwoName}`;
+					lobbyName = lobbyForm.qualifier == true ? `${lobby.tournament.acronym}: Qualifier lobby: ${lobbyForm.qualifierLobbyIdentifier}` : lobbyForm.lobbyWithBrackets == true ? `${lobby.tournament.acronym}: (${lobby.getEscapedTeamOneName()}) vs (${lobby.getEscapedTeamTwoName()})` : `${lobby.tournament.acronym}: ${lobby.getEscapedTeamOneName()} vs ${lobby.getEscapedTeamTwoName()}`;
 				}
 
 				this.creatingMultiplayerLobby = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,12 +2969,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bancho.js@^0.9.7:
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/bancho.js/-/bancho.js-0.9.7.tgz#0fc87c897aced6da3aa71bf41221d2173ed5d287"
-  integrity sha512-0W08wnmzWWg+Pyqi2RSrPFrrYJcj8zZNRnrTSUZunxnQOXRQavx9bdZXEe6uF4l3WShzoo8aeYjrZrgZnvdcHg==
+bancho.js@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/bancho.js/-/bancho.js-0.12.0.tgz#33d6b7847b9b5d0135a18d1e6e35eb590ca1ccda"
+  integrity sha512-o7lGwDltY+nYQmOzSAKBr3COue9cY+I7zICcYkNEPujK0EqOq3n/DHLFO4fAmAUlQ0iPUA98uu47CMVqjJZPwA==
   dependencies:
     nodesu "^0.7.2"
+    rate-limiter-flexible "^2.3.12"
 
 base64-js@^1.2.0, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
@@ -8429,6 +8430,11 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+rate-limiter-flexible@^2.3.12:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-2.4.2.tgz#2a219cc473f015142fd8fb599371223d730decbd"
+  integrity sha512-rMATGGOdO1suFyf/mI5LYhts71g1sbdhmd6YvdiXO2gJnd42Tt6QS4JUKJKSWVVkMtBacm6l40FR7Trjo6Iruw==
 
 raw-body@2.5.1:
   version "2.5.1"


### PR DESCRIPTION
- Lobbies can now be created again if a team name contains a censored word
- Team names are now escaped when creating a new lobby, preventing the client from making a multiplayer lobby with the id `-1`