### PR TITLE
Fix match creation after toggling `Manually enter participant names`

### DIFF
--- a/src/app/modules/lobby/components/lobby-form/lobby-form.component.ts
+++ b/src/app/modules/lobby/components/lobby-form/lobby-form.component.ts
@@ -245,8 +245,8 @@ export class LobbyFormComponent implements OnInit {
 			this.validationForm.removeControl('selected-match-id');
 		}
 		else {
-			this.validationForm.removeControl('team-one-name');
-			this.validationForm.removeControl('team-two-name');
+			this.validationForm.addControl('team-one-name', new FormControl());
+			this.validationForm.addControl('team-two-name', new FormControl());
 
 			this.initializeMatchFilter();
 		}


### PR DESCRIPTION
Fixed an issue where if you toggled `Manually enter participant names` on and off, it prevented match creation from the match dropdown list