### PR TITLE
Display message when no players are available to invite

### DIFF
--- a/src/app/modules/irc/components/irc/irc.component.html
+++ b/src/app/modules/irc/components/irc/irc.component.html
@@ -404,6 +404,10 @@
 								<div class="invite-team">
 									<h3>{{ selectedLobby.teamOneName }}</h3>
 
+									<div *ngIf="selectedLobby.getTeamPlayersFromTournament(selectedLobby.teamOneName).length == 0">
+										<div class="name">No players in team to invite.</div>
+									</div>
+
 									<div class="player" *ngFor="let player of selectedLobby.getTeamPlayersFromTournament(selectedLobby.teamOneName)">
 										<div class="name" [title]="player.name">
 											{{ player.name }}
@@ -428,6 +432,10 @@
 
 								<div class="invite-team">
 									<h3>{{ selectedLobby.teamTwoName }}</h3>
+
+									<div *ngIf="selectedLobby.getTeamPlayersFromTournament(selectedLobby.teamTwoName).length == 0">
+										<div class="name">No players in team to invite.</div>
+									</div>
 
 									<div class="player" *ngFor="let player of selectedLobby.getTeamPlayersFromTournament(selectedLobby.teamTwoName)">
 										<div class="name" [title]="player.name">


### PR DESCRIPTION
Displays a message when no players are available to invite, so referees have a better indication of what is happening. 
See #164 