### PR TITLE
Add new dialog to bulk add teams with players

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wyreferee",
-	"version": "6.9.15",
+	"version": "6.9.16",
 	"description": "Referee client",
 	"author": {
 		"name": "Wesley"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { UpdaterComponent } from './layout/updater/updater.component';
 import { MarkdownModule } from 'ngx-markdown';
 import { CredentialsInterceptor } from './core/interceptors/credentials.interceptor';
 import { ProtectBeatmapDialogComponent } from './components/dialogs/protect-beatmap-dialog/protect-beatmap-dialog.component';
+import { AddBulkTeamsDialogComponent } from './components/dialogs/add-bulk-teams-dialog/add-bulk-teams-dialog.component';
 
 @NgModule({
 	declarations: [
@@ -55,6 +56,7 @@ import { ProtectBeatmapDialogComponent } from './components/dialogs/protect-beat
 		IrcPickMapSameModBracketComponent,
 		IrcShortcutWarningDialogComponent,
 		ProtectBeatmapDialogComponent,
+		AddBulkTeamsDialogComponent,
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/components/dialogs/add-bulk-teams-dialog/add-bulk-teams-dialog.component.html
+++ b/src/app/components/dialogs/add-bulk-teams-dialog/add-bulk-teams-dialog.component.html
@@ -1,0 +1,37 @@
+<h2 mat-dialog-title>Add bulk teams</h2>
+
+<mat-dialog-content class="mat-typography">
+	<p>Enter one team per line using the following format:</p>
+	<code>Team name, Player 1 name, Player 1 id, Player 2 name, Player 2 id, ...</code>
+
+	<ul>
+		<li><b>Team name</b> is required</li>
+		<li>You can add multiple players per team, or none at all</li>
+		<li>Each player must follow the format: <code>username, user ID</code></li>
+		<li>If a player is added, both the <b>username</b> and <b>user ID</b> are required</li>
+		<ul>
+			<li>However, the <b>user ID</b> may be left empty if unknown. See the last example.</li>
+		</ul>
+		<li>Separate each player with a comma</li>
+	</ul>
+
+	<p>Examples:</p>
+
+	<code>Team 1, Player 1, 1234567, Player 2, 7654321</code><br />
+	<code>Team 2, Player 4, 1234567, Player 5, 7654321, Player 6, 1726354</code><br />
+	<code>Team 3, Player 7, 1234567</code><br />
+	<code>Team 4</code><br />
+	<code>Team 5, Player 8, , Player 9, </code><br />
+
+	<hr />
+
+	<mat-form-field class="full-width margin-top">
+		<mat-label>Teams (click on me)</mat-label>
+		<textarea matInput [(ngModel)]="bulkTeams" [ngModelOptions]="{ standalone: true }" rows="8"></textarea>
+	</mat-form-field>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+	<button mat-button [mat-dialog-close]="null">Cancel</button>
+	<button mat-button [mat-dialog-close]="bulkTeams" [disabled]="bulkTeams.length <= 0" color="accent">Create teams</button>
+</mat-dialog-actions>

--- a/src/app/components/dialogs/add-bulk-teams-dialog/add-bulk-teams-dialog.component.spec.ts
+++ b/src/app/components/dialogs/add-bulk-teams-dialog/add-bulk-teams-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddBulkTeamsDialogComponent } from './add-bulk-teams-dialog.component';
+
+describe('AddBulkTeamsDialogComponent', () => {
+	let component: AddBulkTeamsDialogComponent;
+	let fixture: ComponentFixture<AddBulkTeamsDialogComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [AddBulkTeamsDialogComponent]
+		})
+			.compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(AddBulkTeamsDialogComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/components/dialogs/add-bulk-teams-dialog/add-bulk-teams-dialog.component.ts
+++ b/src/app/components/dialogs/add-bulk-teams-dialog/add-bulk-teams-dialog.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+	selector: 'app-add-bulk-teams-dialog',
+	templateUrl: './add-bulk-teams-dialog.component.html',
+	styleUrls: ['./add-bulk-teams-dialog.component.scss']
+})
+export class AddBulkTeamsDialogComponent implements OnInit {
+	bulkTeams: string;
+
+	constructor() {
+		this.bulkTeams = '';
+
+		// Test data, uncomment to use
+		// this.bulkTeams = 'Team 1, Player 1, 1234567, Player 2, 7654321\n' +
+		// 	'Team 2, Player 3, 1234567, Player 2, 7654321, Player 3, 1726354\n' +
+		// 	'Team 3, Player 5, 1234567, Player 6, 7654321\n' +
+		// 	'Team 3, Player 4, 1234567\n' +
+		// 	'Team 4\n' +
+		// 	'Team 5, Player 7, , Player 8, ';
+	}
+
+	ngOnInit(): void { }
+}

--- a/src/app/modules/tournament-management/components-utility/tournament/tournament-participants/tournament-participants.component.html
+++ b/src/app/modules/tournament-management/components-utility/tournament/tournament-participants/tournament-participants.component.html
@@ -7,20 +7,13 @@
 
 				<div class="buttons">
 					<button mat-raised-button (click)="addTeam()" color="primary"><mat-icon>add</mat-icon> add new team</button>
-					<button mat-raised-button (click)="addBulkTeams()" color="primary" [disabled]="teamsToAdd == null || teamsToAdd.length <= 0"><mat-icon>add</mat-icon> add bulk teams</button>
+					<button mat-raised-button (click)="addBulkTeams()" color="primary"><mat-icon>add</mat-icon> add bulk teams</button>
 					<button mat-raised-button (click)="importWyBinTeams()" color="primary" *ngIf="tournament.hasWyBinConnected()">
 						<mat-icon>add</mat-icon> <mat-icon class="sync" [ngClass]="{'rotate': importingFromWyBin == true}">sync</mat-icon>import teams from wyBin
 					</button>
 				</div>
 
 				<div class="split">
-					<div class="col">
-						<mat-form-field class="full-width margin-top">
-							<mat-label>Bulk add teams, list all teams. 1 team per line (click me)</mat-label>
-							<textarea matInput [(ngModel)]="teamsToAdd" [ngModelOptions]="{standalone: true}"></textarea>
-						</mat-form-field>
-					</div>
-
 					<div class="col">
 						<mat-form-field class="full-width margin-top">
 							<mat-label>Filter players/teams by name</mat-label>


### PR DESCRIPTION
Add a new dialog that supports adding teams + players at the same time

Supported formats:
- `Team 1, Player 1, 1234567, Player 2, 7654321`
- `Team 2, Player 4, 1234567, Player 5, 7654321, Player 6, 1726354`
- `Team 3, Player 7, 1234567`
- `Team 4`
- `Team 5, Player 8, , Player 9, `