### PR TITLE
Mappool mods validation

### DIFF
--- a/src/app/modules/tournament-management/components-utility/tournament/tournament-mappool/mappool/mappool.component.ts
+++ b/src/app/modules/tournament-management/components-utility/tournament/tournament-mappool/mappool/mappool.component.ts
@@ -7,6 +7,7 @@ import { WyModCategory } from 'app/models/wytournament/mappool/wy-mod-category';
 import { WyTournament } from 'app/models/wytournament/wy-tournament';
 import { Gamemodes, Mods } from 'app/models/osu-models/osu';
 import { WyMod } from 'app/models/wytournament/mappool/wy-mod';
+import { modBracketUniqueModsValidator } from 'app/modules/tournament-management/models/mod-bracket-unique-mods-validator';
 
 @Component({
 	selector: 'app-mappool',
@@ -150,6 +151,9 @@ export class MappoolComponent implements OnInit {
 		}
 
 		this.createDefaultBracket('Tiebreaker', 'TB', [{ name: 'Freemod', value: 'freemod' }]);
+
+		this.validationForm.setValidators(modBracketUniqueModsValidator());
+		this.validationForm.updateValueAndValidity();
 	}
 
 	/**

--- a/src/app/modules/tournament-management/components-utility/tournament/tournament-mappool/mod-bracket/mod-bracket.component.ts
+++ b/src/app/modules/tournament-management/components-utility/tournament/tournament-mappool/mod-bracket/mod-bracket.component.ts
@@ -12,6 +12,7 @@ import { WyModBracket } from 'app/models/wytournament/mappool/wy-mod-bracket';
 import { WyModBracketMap } from 'app/models/wytournament/mappool/wy-mod-bracket-map';
 import { WyModCategory } from 'app/models/wytournament/mappool/wy-mod-category';
 import { WyTournament } from 'app/models/wytournament/wy-tournament';
+import { modBracketUniqueModsValidator } from 'app/modules/tournament-management/models/mod-bracket-unique-mods-validator';
 import { ElectronService } from 'app/services/electron.service';
 import { GetBeatmap } from 'app/services/osu-api/get-beatmap.service';
 import { ToastService } from 'app/services/toast.service';
@@ -122,6 +123,9 @@ export class ModBracketComponent implements OnInit {
 					}
 				}
 
+				this.validationForm.setValidators(modBracketUniqueModsValidator());
+				this.validationForm.updateValueAndValidity();
+
 				this.toastService.addToast(`Successfully removed "${modBracket.name}" from the mappool.`);
 			}
 		});
@@ -140,6 +144,9 @@ export class ModBracketComponent implements OnInit {
 			this.modBracket.mods.push(newMod);
 
 			this.validationForm.addControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-mod-${newMod.index}-value`, new FormControl('', Validators.required));
+
+			this.validationForm.setValidators(modBracketUniqueModsValidator());
+			this.validationForm.updateValueAndValidity();
 		}
 		else {
 			this.toastService.addToast('Maximum amount of mods reached.', ToastType.Warning);
@@ -157,6 +164,9 @@ export class ModBracketComponent implements OnInit {
 				this.validationForm.removeControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-mod-${this.modBracket.mods[mod].index}-value`);
 
 				this.modBracket.mods.splice(Number(mod), 1);
+
+				this.validationForm.setValidators(modBracketUniqueModsValidator());
+				this.validationForm.updateValueAndValidity();
 				return;
 			}
 		}
@@ -278,6 +288,9 @@ export class ModBracketComponent implements OnInit {
 		if (this.mappool.type == MappoolType.CTMTournament) {
 			this.validationForm.removeControl(`mappool-${this.mappool.index}-mod-bracket-${this.modBracket.index}-beatmap-${beatmap.index}-damage-amount`);
 		}
+
+		this.validationForm.setValidators(modBracketUniqueModsValidator());
+		this.validationForm.updateValueAndValidity();
 	}
 
 	/**

--- a/src/app/modules/tournament-management/components/tournament-manage/tournament-create/tournament-create.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-manage/tournament-create/tournament-create.component.ts
@@ -90,6 +90,17 @@ export class TournamentCreateComponent implements OnInit {
 				}
 			}
 
+			for (const errorKey in this.validationForm.errors) {
+				if (errorKey == 'nonUniqueModBracketValues') {
+					const modBracketErrors = this.validationForm.errors[errorKey];
+
+					for (const modBracketError of modBracketErrors) {
+						const errorMessage = this.validationErrorService.getErrorMessage(modBracketError);
+						this.errors.push(errorMessage);
+					}
+				}
+			}
+
 			this.container.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
 			return;

--- a/src/app/modules/tournament-management/components/tournament-manage/tournament-edit/tournament-edit.component.ts
+++ b/src/app/modules/tournament-management/components/tournament-manage/tournament-edit/tournament-edit.component.ts
@@ -7,6 +7,7 @@ import { CTMCalculation } from 'app/models/score-calculation/calculation-types/c
 import { ToastType } from 'app/models/toast';
 import { MappoolType } from 'app/models/wytournament/mappool/wy-mappool';
 import { WyTournament } from 'app/models/wytournament/wy-tournament';
+import { modBracketUniqueModsValidator } from 'app/modules/tournament-management/models/mod-bracket-unique-mods-validator';
 import { ValidationErrorService } from 'app/modules/tournament-management/services/validation-error.service';
 import { ToastService } from 'app/services/toast.service';
 import { TournamentService } from 'app/services/tournament.service';
@@ -148,6 +149,9 @@ export class TournamentEditComponent implements OnInit {
 					}
 				}
 
+				this.validationForm.setValidators(modBracketUniqueModsValidator());
+				this.validationForm.updateValueAndValidity();
+
 				this.tournament = tournament;
 			}
 		});
@@ -192,6 +196,17 @@ export class TournamentEditComponent implements OnInit {
 				if (control.errors != null) {
 					const errorMessage = this.validationErrorService.getErrorMessage(validatorKey);
 					this.errors.push(errorMessage);
+				}
+			}
+
+			for (const errorKey in this.validationForm.errors) {
+				if (errorKey == 'nonUniqueModBracketValues') {
+					const modBracketErrors = this.validationForm.errors[errorKey];
+
+					for (const modBracketError of modBracketErrors) {
+						const errorMessage = this.validationErrorService.getErrorMessage(modBracketError);
+						this.errors.push(errorMessage);
+					}
 				}
 			}
 

--- a/src/app/modules/tournament-management/models/mod-bracket-unique-mods-validator.ts
+++ b/src/app/modules/tournament-management/models/mod-bracket-unique-mods-validator.ts
@@ -1,0 +1,55 @@
+import { ValidatorFn, AbstractControl, ValidationErrors } from "@angular/forms";
+
+export function modBracketUniqueModsValidator(): ValidatorFn {
+	return (form: AbstractControl): ValidationErrors | null => {
+		if (!form || typeof form !== 'object' || !('controls' in form)) return null;
+
+		const controls = (form as any).controls;
+		const bracketMap = new Map<string, { key: string, value: string }[]>();
+		const duplicateKeys: string[] = [];
+
+		for (const key of Object.keys(controls)) {
+			const match = key.match(/^(mappool-\d+-mod-bracket-\d+)-mod-\d+-value$/);
+
+			if (match) {
+				const bracketKey = match[1];
+				const rawValue = controls[key].value;
+				const value = rawValue !== null && rawValue !== undefined ? String(rawValue).trim() : '';
+
+				if (!value) continue;
+
+				if (!bracketMap.has(bracketKey)) {
+					bracketMap.set(bracketKey, []);
+				}
+
+				bracketMap.get(bracketKey)!.push({ key, value });
+			}
+		}
+
+		for (const [bracketKey, entries] of bracketMap.entries()) {
+			const valueMap = new Map<string, string[]>();
+
+			for (const { key, value } of entries) {
+				if (!valueMap.has(value)) {
+					valueMap.set(value, []);
+				}
+
+				valueMap.get(value)!.push(key);
+			}
+
+			for (const keys of valueMap.values()) {
+				if (keys.length > 1) {
+					duplicateKeys.push(...keys.map(k => `${k}-not-unique`));
+				}
+			}
+		}
+
+		if (duplicateKeys.length > 0) {
+			return {
+				nonUniqueModBracketValues: duplicateKeys
+			};
+		}
+
+		return null;
+	};
+}

--- a/src/app/modules/tournament-management/models/mod-bracket-unique-mods-validator.ts
+++ b/src/app/modules/tournament-management/models/mod-bracket-unique-mods-validator.ts
@@ -1,11 +1,13 @@
-import { ValidatorFn, AbstractControl, ValidationErrors } from "@angular/forms";
+import { ValidatorFn, AbstractControl, ValidationErrors } from '@angular/forms';
 
 export function modBracketUniqueModsValidator(): ValidatorFn {
 	return (form: AbstractControl): ValidationErrors | null => {
-		if (!form || typeof form !== 'object' || !('controls' in form)) return null;
+		if (!form || typeof form !== 'object' || !('controls' in form)) {
+			return null;
+		}
 
 		const controls = (form as any).controls;
-		const bracketMap = new Map<string, { key: string, value: string }[]>();
+		const bracketMap = new Map<string, { key: string; value: string }[]>();
 		const duplicateKeys: string[] = [];
 
 		for (const key of Object.keys(controls)) {
@@ -16,17 +18,19 @@ export function modBracketUniqueModsValidator(): ValidatorFn {
 				const rawValue = controls[key].value;
 				const value = rawValue !== null && rawValue !== undefined ? String(rawValue).trim() : '';
 
-				if (!value) continue;
+				if (!value) {
+					continue;
+				}
 
 				if (!bracketMap.has(bracketKey)) {
 					bracketMap.set(bracketKey, []);
 				}
 
-				bracketMap.get(bracketKey)!.push({ key, value });
+				bracketMap.get(bracketKey).push({ key, value });
 			}
 		}
 
-		for (const [bracketKey, entries] of bracketMap.entries()) {
+		for (const [, entries] of bracketMap.entries()) {
 			const valueMap = new Map<string, string[]>();
 
 			for (const { key, value } of entries) {
@@ -34,7 +38,7 @@ export function modBracketUniqueModsValidator(): ValidatorFn {
 					valueMap.set(value, []);
 				}
 
-				valueMap.get(value)!.push(key);
+				valueMap.get(value).push(key);
 			}
 
 			for (const keys of valueMap.values()) {

--- a/src/app/modules/tournament-management/services/validation-error.service.ts
+++ b/src/app/modules/tournament-management/services/validation-error.service.ts
@@ -40,7 +40,8 @@ export class ValidationErrorService {
 			new ValidationError('mappool-(\\d+)-type', 'You have to set the type for the {0} mappool.'),
 			new ValidationError('mappool-(\\d+)-mod-bracket-(\\d+)-name', 'You have to set the name for the {1} mod bracket from the {0} mappool.'),
 			new ValidationError('mappool-(\\d+)-mod-bracket-(\\d+)-acronym', 'You have to set the acronym for the {1} mod bracket from the {0} mappool.'),
-			new ValidationError('mappool-(\\d+)-mod-bracket-(\\d+)-mod-(\\d+)-value', 'You have to select a mod for the {3} mod dropdown of the {2} mod bracket from the {1} mappool.'),
+			new ValidationError('mappool-(\\d+)-mod-bracket-(\\d+)-mod-(\\d+)-value-not-unique', 'The {2} mod is a duplicate for the {1} mod bracket from the {0} mappool.'),
+			new ValidationError('mappool-(\\d+)-mod-bracket-(\\d+)-mod-(\\d+)-value', 'You have to select a mod for the {2} mod dropdown of the {1} mod bracket from the {0} mappool.'),
 		];
 	}
 
@@ -51,7 +52,7 @@ export class ValidationErrorService {
 	 */
 	getErrorMessage(validatorKey: string): string {
 		for (const validator of this.validators) {
-			if (validator.match(validatorKey)) {
+			if (validator.match(`^${validatorKey}$`)) {
 				return validator.parseErrorMessage(validatorKey);
 			}
 		}


### PR DESCRIPTION
Implement mappool mod bracket mods validation, so you can no longer have duplicate mods.

Prevents from having `NoFail + NoFail = Easy` from happening (or whatever other combinations happen)